### PR TITLE
fix correct platform being used in HM_PLATFORM_ARCH

### DIFF
--- a/buildroot-external/package/recovery-system/external/package/hm-platform/hm-platform.mk
+++ b/buildroot-external/package/recovery-system/external/package/hm-platform/hm-platform.mk
@@ -6,33 +6,33 @@
 #############################################################
 
 HM_PLATFORM_VERSION = $(OCCU_VERSION)
-HM_PLATFORM_SITE = $(call github,jens-maus,occu,$(OCCU_VERSION))
+HM_PLATFORM_SITE = $(call github,OpenCCU,occu,$(OCCU_VERSION))
 
 ifeq ($(BR2_arm),y)
 	HM_PLATFORM_ARCH=arm-gnueabihf-gcc8
 endif
 
 ifeq ($(BR2_aarch64),y)
-	HM_PLATFORM_ARCH=arm-gnueabihf-gcc8
+	HM_PLATFORM_ARCH=aarch64-linux-gnu
 endif
 
 ifeq ($(BR2_i386),y)
-	HM_PLATFORM_ARCH=X86_32_GCC8
+	HM_PLATFORM_ARCH=i686-linux-gnu
 endif
 
 ifeq ($(BR2_x86_64),y)
-	HM_PLATFORM_ARCH=X86_32_GCC8
+	HM_PLATFORM_ARCH=x86_64-linux-gnu
 endif
 
 define HM_PLATFORM_INSTALL_TARGET_CMDS
-	$(INSTALL) -D -m 0755 $(@D)/$(HM_PLATFORM_ARCH)/packages-eQ-3/LinuxBasis/bin/ssdpd $(TARGET_DIR)/bin/ssdpd
-	$(INSTALL) -D -m 0755 $(@D)/$(HM_PLATFORM_ARCH)/packages-eQ-3/LinuxBasis/bin/eq3configcmd $(TARGET_DIR)/bin/eq3configcmd
-	$(INSTALL) -D -m 0755 $(@D)/$(HM_PLATFORM_ARCH)/packages-eQ-3/LinuxBasis/bin/eq3configd $(TARGET_DIR)/bin/eq3configd
-	$(INSTALL) -D -m 0755 $(@D)/$(HM_PLATFORM_ARCH)/packages-eQ-3/LinuxBasis/lib/libeq3config.so $(TARGET_DIR)/lib/libeq3config.so
-	$(INSTALL) -D -m 0755 $(@D)/$(HM_PLATFORM_ARCH)/packages-eQ-3/RFD/bin/crypttool $(TARGET_DIR)/bin/crypttool
-	$(INSTALL) -D -m 0755 $(@D)/$(HM_PLATFORM_ARCH)/packages-eQ-3/RFD/lib/libLanDeviceUtils.so $(TARGET_DIR)/lib/libLanDeviceUtils.so
-	$(INSTALL) -D -m 0755 $(@D)/$(HM_PLATFORM_ARCH)/packages-eQ-3/RFD/lib/libUnifiedLanComm.so $(TARGET_DIR)/lib/libUnifiedLanComm.so
-	$(INSTALL) -D -m 0755 $(@D)/$(HM_PLATFORM_ARCH)/packages-eQ-3/RFD/lib/libelvutils.so $(TARGET_DIR)/lib/libelvutils.so
+	$(INSTALL) -D -m 0755 $(@D)/$(HM_PLATFORM_ARCH)/packages-eQ-3/LinuxBasis-Beta/bin/ssdpd $(TARGET_DIR)/bin/ssdpd
+	$(INSTALL) -D -m 0755 $(@D)/$(HM_PLATFORM_ARCH)/packages-eQ-3/LinuxBasis-Beta/bin/eq3configcmd $(TARGET_DIR)/bin/eq3configcmd
+	$(INSTALL) -D -m 0755 $(@D)/$(HM_PLATFORM_ARCH)/packages-eQ-3/LinuxBasis-Beta/bin/eq3configd $(TARGET_DIR)/bin/eq3configd
+	$(INSTALL) -D -m 0755 $(@D)/$(HM_PLATFORM_ARCH)/packages-eQ-3/LinuxBasis-Beta/lib/libeq3config.so $(TARGET_DIR)/lib/libeq3config.so
+	$(INSTALL) -D -m 0755 $(@D)/$(HM_PLATFORM_ARCH)/packages-eQ-3/RFD-Beta/bin/crypttool $(TARGET_DIR)/bin/crypttool
+	$(INSTALL) -D -m 0755 $(@D)/$(HM_PLATFORM_ARCH)/packages-eQ-3/RFD-Beta/lib/libLanDeviceUtils.so $(TARGET_DIR)/lib/libLanDeviceUtils.so
+	$(INSTALL) -D -m 0755 $(@D)/$(HM_PLATFORM_ARCH)/packages-eQ-3/RFD-Beta/lib/libUnifiedLanComm.so $(TARGET_DIR)/lib/libUnifiedLanComm.so
+	$(INSTALL) -D -m 0755 $(@D)/$(HM_PLATFORM_ARCH)/packages-eQ-3/RFD-Beta/lib/libelvutils.so $(TARGET_DIR)/lib/libelvutils.so
 	cp -a $(HM_PLATFORM_PKGDIR)/rootfs-overlay/* $(TARGET_DIR)/
 endef
 

--- a/buildroot-external/package/recovery-system/external/package/hm-platform/hm-platform.mk
+++ b/buildroot-external/package/recovery-system/external/package/hm-platform/hm-platform.mk
@@ -8,6 +8,10 @@
 HM_PLATFORM_VERSION = $(OCCU_VERSION)
 HM_PLATFORM_SITE = $(call github,OpenCCU,occu,$(OCCU_VERSION))
 
+ifeq ($(BR2_TOOLCHAIN_USES_GLIBC),)
+	$(error hm-platform requires a glibc toolchain (BR2_TOOLCHAIN_USES_GLIBC))
+endif
+
 ifeq ($(BR2_arm),y)
 	HM_PLATFORM_ARCH=arm-gnueabihf-gcc8
 endif
@@ -24,16 +28,18 @@ ifeq ($(BR2_x86_64),y)
 	HM_PLATFORM_ARCH=x86_64-linux-gnu
 endif
 
+HM_PLATFORM_BETA_SUFFIX ?= -Beta
+
 define HM_PLATFORM_INSTALL_TARGET_CMDS
-	$(INSTALL) -D -m 0755 $(@D)/$(HM_PLATFORM_ARCH)/packages-eQ-3/LinuxBasis-Beta/bin/ssdpd $(TARGET_DIR)/bin/ssdpd
-	$(INSTALL) -D -m 0755 $(@D)/$(HM_PLATFORM_ARCH)/packages-eQ-3/LinuxBasis-Beta/bin/eq3configcmd $(TARGET_DIR)/bin/eq3configcmd
-	$(INSTALL) -D -m 0755 $(@D)/$(HM_PLATFORM_ARCH)/packages-eQ-3/LinuxBasis-Beta/bin/eq3configd $(TARGET_DIR)/bin/eq3configd
-	$(INSTALL) -D -m 0755 $(@D)/$(HM_PLATFORM_ARCH)/packages-eQ-3/LinuxBasis-Beta/lib/libeq3config.so $(TARGET_DIR)/lib/libeq3config.so
-	$(INSTALL) -D -m 0755 $(@D)/$(HM_PLATFORM_ARCH)/packages-eQ-3/RFD-Beta/bin/crypttool $(TARGET_DIR)/bin/crypttool
-	$(INSTALL) -D -m 0755 $(@D)/$(HM_PLATFORM_ARCH)/packages-eQ-3/RFD-Beta/lib/libLanDeviceUtils.so $(TARGET_DIR)/lib/libLanDeviceUtils.so
-	$(INSTALL) -D -m 0755 $(@D)/$(HM_PLATFORM_ARCH)/packages-eQ-3/RFD-Beta/lib/libUnifiedLanComm.so $(TARGET_DIR)/lib/libUnifiedLanComm.so
-	$(INSTALL) -D -m 0755 $(@D)/$(HM_PLATFORM_ARCH)/packages-eQ-3/RFD-Beta/lib/libelvutils.so $(TARGET_DIR)/lib/libelvutils.so
-	cp -a $(HM_PLATFORM_PKGDIR)/rootfs-overlay/* $(TARGET_DIR)/
+	$(INSTALL) -D -m 0755 $(@D)/$(HM_PLATFORM_ARCH)/packages-eQ-3/LinuxBasis$(HM_PLATFORM_BETA_SUFFIX)/bin/ssdpd $(TARGET_DIR)/bin/ssdpd
+	$(INSTALL) -D -m 0755 $(@D)/$(HM_PLATFORM_ARCH)/packages-eQ-3/LinuxBasis$(HM_PLATFORM_BETA_SUFFIX)/bin/eq3configcmd $(TARGET_DIR)/bin/eq3configcmd
+	$(INSTALL) -D -m 0755 $(@D)/$(HM_PLATFORM_ARCH)/packages-eQ-3/LinuxBasis$(HM_PLATFORM_BETA_SUFFIX)/bin/eq3configd $(TARGET_DIR)/bin/eq3configd
+	$(INSTALL) -D -m 0644 $(@D)/$(HM_PLATFORM_ARCH)/packages-eQ-3/LinuxBasis$(HM_PLATFORM_BETA_SUFFIX)/lib/libeq3config.so $(TARGET_DIR)/lib/libeq3config.so
+	$(INSTALL) -D -m 0755 $(@D)/$(HM_PLATFORM_ARCH)/packages-eQ-3/RFD$(HM_PLATFORM_BETA_SUFFIX)/bin/crypttool $(TARGET_DIR)/bin/crypttool
+	$(INSTALL) -D -m 0644 $(@D)/$(HM_PLATFORM_ARCH)/packages-eQ-3/RFD$(HM_PLATFORM_BETA_SUFFIX)/lib/libLanDeviceUtils.so $(TARGET_DIR)/lib/libLanDeviceUtils.so
+	$(INSTALL) -D -m 0644 $(@D)/$(HM_PLATFORM_ARCH)/packages-eQ-3/RFD$(HM_PLATFORM_BETA_SUFFIX)/lib/libUnifiedLanComm.so $(TARGET_DIR)/lib/libUnifiedLanComm.so
+	$(INSTALL) -D -m 0644 $(@D)/$(HM_PLATFORM_ARCH)/packages-eQ-3/RFD$(HM_PLATFORM_BETA_SUFFIX)/lib/libelvutils.so $(TARGET_DIR)/lib/libelvutils.so
+	cp -a $(HM_PLATFORM_PKGDIR)/rootfs-overlay/. $(TARGET_DIR)/
 endef
 
 define HM_PLATFORM_INSTALL_INIT_SYSV


### PR DESCRIPTION
This change modifies the HM_PLATFORM_ARCH variable in hm-platform.mk so that the correct 32bit/64bit binaries should be picked up from the OCCU repository. In addition, HM_PLATFORM_SITE uses the correct github "OpenCCU" organization now where our occu branch is located now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Chores
  - Switched upstream source to OpenCCU.
  - Added a Beta packaging suffix and adjusted install targets to use Beta paths.

* Refactor
  - Updated architecture toolchain mappings for aarch64, i386, and x86_64 to modern GNU triples.

* Bug Fixes
  - Adjusted install details: libeq3config.so permission set to 0644 and rootfs-overlay copy behavior updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->