### PR TITLE
modify package SITE references of occu and cloudmatic package

### DIFF
--- a/buildroot-external/package/cloudmatic/cloudmatic.mk
+++ b/buildroot-external/package/cloudmatic/cloudmatic.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 CLOUDMATIC_VERSION = 4bc76aab7e0bd6b7f1ac1802ed9713d595f536de
-CLOUDMATIC_SITE = $(call github,jens-maus,CloudMatic-CCUAddon,$(CLOUDMATIC_VERSION))
+CLOUDMATIC_SITE = $(call github,OpenCCU,CloudMatic-CCUAddon,$(CLOUDMATIC_VERSION))
 CLOUDMATIC_LICENSE = BSD-3-Clause
 
 ifeq ($(BR2_arm),y)

--- a/buildroot-external/package/occu/occu.mk
+++ b/buildroot-external/package/occu/occu.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 OCCU_VERSION = 3.83.6-5
-OCCU_SITE = $(call github,jens-maus,occu,$(OCCU_VERSION))
+OCCU_SITE = $(call github,OpenCCU,occu,$(OCCU_VERSION))
 OCCU_LICENSE = HMSL
 OCCU_LICENSE_FILES = LicenseDE.txt
 


### PR DESCRIPTION
This change modifies the cloudmatic.mk and occu.mk files to use correct SITE variable github references to directly use the repositories located in our new OpenCCU organization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Repointed CloudMatic add-on and OCCU package sources to the OpenCCU repositories.
  * Aligns dependencies with the current upstream, improving reliability and future maintainability.
  * No user-facing behavior changes expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->