### PR TITLE
add missing fs.h include to fix GCC14 compile of uboot 2023.01

### DIFF
--- a/buildroot-external/patches/uboot/2023.01/0001-CMD-read-string-from-fileinto-env.patch
+++ b/buildroot-external/patches/uboot/2023.01/0001-CMD-read-string-from-fileinto-env.patch
@@ -24,10 +24,11 @@
  obj-$(CONFIG_CMD_STRINGS) += strings.o
 --- a/cmd/fileenv.c	1970-01-01 01:00:00.000000000 +0100
 +++ b/cmd/fileenv.c	2025-01-30 23:56:16.396279241 +0100
-@@ -0,0 +1,45 @@
+@@ -0,0 +1,46 @@
 +#include <config.h>
 +#include <common.h>
 +#include <command.h>
++#include <fs.h>
 +#include <linux/ctype.h>
 +
 +static char *fs_argv[5];


### PR DESCRIPTION
This change adds missing fs.h include statement to the fileenv.c file being introduced in the 0001-CMD-read-string-from-fileinto-env patch set which broke compilation with GCC14 because of implicit declarations being defined as errors with GCC14+.