### PR TITLE
minor fixes to Config.in of multilib32 and recovery-system br package

### DIFF
--- a/buildroot-external/package/multilib32/Config.in
+++ b/buildroot-external/package/multilib32/Config.in
@@ -1,5 +1,10 @@
 config BR2_PACKAGE_MULTILIB32
-	bool "On a 64bit systems this package allows recompile the used toolchain for 32bit systems and stores the created libraries to /lib32,/usr/lib32 accordingly"
+	bool "multilib32"
+	help
+	  On 64bit systems this virtual package allows compile the used
+	  toolchain for 32bit systems and stores the created libraries
+	  to /lib32,/usr/lib32 accordingly so that a multlib env is
+	  available for execution of 64+32bit binaries.
 
 config BR2_PACKAGE_MULTILIB32_CONFIG_FRAGMENT_FILE
 	string "kconfig fragment file"

--- a/buildroot-external/package/multilib32/Config.in
+++ b/buildroot-external/package/multilib32/Config.in
@@ -1,10 +1,10 @@
 config BR2_PACKAGE_MULTILIB32
 	bool "multilib32"
 	help
-	  On 64bit systems this virtual package allows compile the used
-	  toolchain for 32bit systems and stores the created libraries
-	  to /lib32,/usr/lib32 accordingly so that a multlib env is
-	  available for execution of 64+32bit binaries.
+	  On 64-bit systems, this virtual package enables 32-bit
+	  multilib support. The created 32-bit libraries are stored
+	  under /lib32 and /usr/lib32 so that both 64-bit and
+	  32-bit binaries can be executed.
 
 config BR2_PACKAGE_MULTILIB32_CONFIG_FRAGMENT_FILE
 	string "kconfig fragment file"

--- a/buildroot-external/package/recovery-system/Config.in
+++ b/buildroot-external/package/recovery-system/Config.in
@@ -1,5 +1,7 @@
 config BR2_PACKAGE_RECOVERY_SYSTEM
-	bool "Creates a dedicated recovery system and provide it as an initrd"
+	bool "RecoverySystem"
+	help
+	  Creates a dedicated recovery system and provide it as an initrd
 
 config BR2_PACKAGE_RECOVERY_SYSTEM_CONFIG_FRAGMENT_FILE
 	string "kconfig fragment file"

--- a/buildroot-external/package/recovery-system/Config.in
+++ b/buildroot-external/package/recovery-system/Config.in
@@ -1,7 +1,8 @@
 config BR2_PACKAGE_RECOVERY_SYSTEM
-	bool "RecoverySystem"
+	bool "recovery-system"
 	help
-	  Creates a dedicated recovery system and provide it as an initrd
+	  Creates a dedicated recovery system and provides it
+	  as an initrd.
 
 config BR2_PACKAGE_RECOVERY_SYSTEM_CONFIG_FRAGMENT_FILE
 	string "kconfig fragment file"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Documentation
  - Simplified labels for "multilib32" and "recovery-system" configuration options.
  - Added help text for multilib32 explaining 32-bit multilib support on 64-bit systems and library locations (/lib32, /usr/lib32).
  - Added help text for recovery-system describing creation of a dedicated recovery initrd.

- Chores
  - Multilib32 config fragment now only applies when multilib32 is enabled, improving configuration consistency and UX.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->