### PR TITLE
fix uboot boot scripts to also check for zImage

### DIFF
--- a/buildroot-external/board/odroid-c2/boot.cmd
+++ b/buildroot-external/board/odroid-c2/boot.cmd
@@ -14,6 +14,11 @@ setenv usbstoragequirks "0x2537:0x1066:u,0x2537:0x1068:u"
 
 echo "Boot script loaded from ${devtype} ${devnum}"
 
+# test if the kernel does not exist and if not we use zImage
+if test ! -e ${devtype} ${devnum}:${rootfs} /${kernel_img}; then
+  setenv kernel_img "z${kernel_img}"
+fi
+
 # import environment from /boot/bootEnv.txt
 if test -e ${devtype} ${devnum}:${bootfs} bootEnv.txt; then
   load ${devtype} ${devnum}:${bootfs} ${load_addr} bootEnv.txt
@@ -23,7 +28,9 @@ fi
 # test if the gpio button is 0 (pressed) or if .recoveryMode exists in userfs
 # or if Image doesn't exist in the root partition
 gpio input ${gpio_button}
-if test $? -eq 0 -o -e ${devtype} ${devnum}:${userfs} /.recoveryMode -o ! -e ${devtype} ${devnum}:${rootfs} ${kernel_img}; then
+if test $? -eq 0 \
+   -o -e ${devtype} ${devnum}:${userfs} /.recoveryMode \
+   -o ! -e ${devtype} ${devnum}:${rootfs} /${kernel_img}; then
   echo "==== STARTING RECOVERY SYSTEM ===="
   # load the initrd file
   load ${devtype} ${devnum}:${bootfs} ${ramdisk_addr_r} ${recoveryfs_initrd}

--- a/buildroot-external/board/odroid-c2/boot.cmd
+++ b/buildroot-external/board/odroid-c2/boot.cmd
@@ -7,16 +7,21 @@ setenv rootfs 2
 setenv userfs 3
 #setenv gpio_button "23" # pin 32 (GPIOY_13)
 setenv gpio_button "disabled"
-setenv kernel_img "Image"
 setenv recoveryfs_initrd "recoveryfs-initrd"
 setenv overlays ""
 setenv usbstoragequirks "0x2537:0x1066:u,0x2537:0x1068:u"
 
 echo "Boot script loaded from ${devtype} ${devnum}"
 
-# test if the kernel does not exist and if not we use zImage
-if test ! -e ${devtype} ${devnum}:${rootfs} /${kernel_img}; then
-  setenv kernel_img "z${kernel_img}"
+# decide kernel image on rootfs
+if test -e ${devtype} ${devnum}:${rootfs} /zImage; then
+  setenv kernel_img /zImage
+  setenv kernel_bootcmd bootz
+else
+  if test -e ${devtype} ${devnum}:${rootfs} /Image; then
+    setenv kernel_img /Image
+    setenv kernel_bootcmd booti
+  fi
 fi
 
 # import environment from /boot/bootEnv.txt
@@ -30,13 +35,14 @@ fi
 gpio input ${gpio_button}
 if test $? -eq 0 \
    -o -e ${devtype} ${devnum}:${userfs} /.recoveryMode \
-   -o ! -e ${devtype} ${devnum}:${rootfs} /${kernel_img}; then
+   -o ! -e ${devtype} ${devnum}:${rootfs} ${kernel_img}; then
   echo "==== STARTING RECOVERY SYSTEM ===="
   # load the initrd file
   load ${devtype} ${devnum}:${bootfs} ${ramdisk_addr_r} ${recoveryfs_initrd}
   setenv rootfs_str "/dev/ram0"
   setenv initrd_addr_r ${ramdisk_addr_r}
-  setenv kernel_img "recoveryfs-Image"
+  setenv kernel_img "/recoveryfs-Image"
+  setenv kernel_bootcmd booti
   setenv kernelfs ${bootfs}
 else
   echo "==== NORMAL BOOT ===="
@@ -76,7 +82,7 @@ setenv bootargs "console=${console} root=${rootfs_str} ro rootfstype=ext4 fsck.r
 load ${devtype} ${devnum}:${kernelfs} ${kernel_addr_r} ${kernel_img}
 
 # boot kernel
-booti ${kernel_addr_r} ${initrd_addr_r} ${fdt_addr_r}
+${kernel_bootcmd} ${kernel_addr_r} ${initrd_addr_r} ${fdt_addr_r}
 
 echo "Boot failed, resetting..."
 reset

--- a/buildroot-external/board/odroid-c2/boot.cmd
+++ b/buildroot-external/board/odroid-c2/boot.cmd
@@ -14,14 +14,12 @@ setenv usbstoragequirks "0x2537:0x1066:u,0x2537:0x1068:u"
 echo "Boot script loaded from ${devtype} ${devnum}"
 
 # decide kernel image on rootfs
-if test -e ${devtype} ${devnum}:${rootfs} /zImage; then
+if test -e ${devtype} ${devnum}:${rootfs} /Image; then
+  setenv kernel_img /Image
+  setenv kernel_bootcmd booti
+else
   setenv kernel_img /zImage
   setenv kernel_bootcmd bootz
-else
-  if test -e ${devtype} ${devnum}:${rootfs} /Image; then
-    setenv kernel_img /Image
-    setenv kernel_bootcmd booti
-  fi
 fi
 
 # import environment from /boot/bootEnv.txt

--- a/buildroot-external/board/odroid-c4/boot.cmd
+++ b/buildroot-external/board/odroid-c4/boot.cmd
@@ -14,6 +14,11 @@ setenv usbstoragequirks "0x2537:0x1066:u,0x2537:0x1068:u"
 
 echo "Boot script loaded from ${devtype} ${devnum}"
 
+# test if the kernel does not exist and if not we use zImage
+if test ! -e ${devtype} ${devnum}:${rootfs} /${kernel_img}; then
+  setenv kernel_img "z${kernel_img}"
+fi
+
 # import environment from /boot/bootEnv.txt
 if test -e ${devtype} ${devnum}:${bootfs} bootEnv.txt; then
   load ${devtype} ${devnum}:${bootfs} ${load_addr} bootEnv.txt
@@ -23,7 +28,9 @@ fi
 # test if the gpio button is 0 (pressed) or if .recoveryMode exists in userfs
 # or if Image doesn't exist in the root partition
 gpio input ${gpio_button}
-if test $? -eq 0 -o -e ${devtype} ${devnum}:${userfs} /.recoveryMode -o ! -e ${devtype} ${devnum}:${rootfs} ${kernel_img}; then
+if test $? -eq 0 \
+   -o -e ${devtype} ${devnum}:${userfs} /.recoveryMode \
+   -o ! -e ${devtype} ${devnum}:${rootfs} /${kernel_img}; then
   echo "==== STARTING RECOVERY SYSTEM ===="
   # load the initrd file
   load ${devtype} ${devnum}:${bootfs} ${ramdisk_addr_r} ${recoveryfs_initrd}

--- a/buildroot-external/board/odroid-c4/boot.cmd
+++ b/buildroot-external/board/odroid-c4/boot.cmd
@@ -7,16 +7,21 @@ setenv rootfs 2
 setenv userfs 3
 #setenv gpio_button "23" # pin 32 (GPIOH_7)
 setenv gpio_button "disabled"
-setenv kernel_img "Image"
 setenv recoveryfs_initrd "recoveryfs-initrd"
 setenv overlays ""
 setenv usbstoragequirks "0x2537:0x1066:u,0x2537:0x1068:u"
 
 echo "Boot script loaded from ${devtype} ${devnum}"
 
-# test if the kernel does not exist and if not we use zImage
-if test ! -e ${devtype} ${devnum}:${rootfs} /${kernel_img}; then
-  setenv kernel_img "z${kernel_img}"
+# decide kernel image on rootfs
+if test -e ${devtype} ${devnum}:${rootfs} /zImage; then
+  setenv kernel_img /zImage
+  setenv kernel_bootcmd bootz
+else
+  if test -e ${devtype} ${devnum}:${rootfs} /Image; then
+    setenv kernel_img /Image
+    setenv kernel_bootcmd booti
+  fi
 fi
 
 # import environment from /boot/bootEnv.txt
@@ -30,13 +35,14 @@ fi
 gpio input ${gpio_button}
 if test $? -eq 0 \
    -o -e ${devtype} ${devnum}:${userfs} /.recoveryMode \
-   -o ! -e ${devtype} ${devnum}:${rootfs} /${kernel_img}; then
+   -o ! -e ${devtype} ${devnum}:${rootfs} ${kernel_img}; then
   echo "==== STARTING RECOVERY SYSTEM ===="
   # load the initrd file
   load ${devtype} ${devnum}:${bootfs} ${ramdisk_addr_r} ${recoveryfs_initrd}
   setenv rootfs_str "/dev/ram0"
   setenv initrd_addr_r ${ramdisk_addr_r}
-  setenv kernel_img "recoveryfs-Image"
+  setenv kernel_img "/recoveryfs-Image"
+  setenv kernel_bootcmd booti
   setenv kernelfs ${bootfs}
 else
   echo "==== NORMAL BOOT ===="
@@ -76,7 +82,7 @@ setenv bootargs "console=${console} root=${rootfs_str} ro rootfstype=ext4 fsck.r
 load ${devtype} ${devnum}:${kernelfs} ${kernel_addr_r} ${kernel_img}
 
 # boot kernel
-booti ${kernel_addr_r} ${initrd_addr_r} ${fdt_addr_r}
+${kernel_bootcmd} ${kernel_addr_r} ${initrd_addr_r} ${fdt_addr_r}
 
 echo "Boot failed, resetting..."
 reset

--- a/buildroot-external/board/odroid-c4/boot.cmd
+++ b/buildroot-external/board/odroid-c4/boot.cmd
@@ -14,14 +14,12 @@ setenv usbstoragequirks "0x2537:0x1066:u,0x2537:0x1068:u"
 echo "Boot script loaded from ${devtype} ${devnum}"
 
 # decide kernel image on rootfs
-if test -e ${devtype} ${devnum}:${rootfs} /zImage; then
+if test -e ${devtype} ${devnum}:${rootfs} /Image; then
+  setenv kernel_img /Image
+  setenv kernel_bootcmd booti
+else
   setenv kernel_img /zImage
   setenv kernel_bootcmd bootz
-else
-  if test -e ${devtype} ${devnum}:${rootfs} /Image; then
-    setenv kernel_img /Image
-    setenv kernel_bootcmd booti
-  fi
 fi
 
 # import environment from /boot/bootEnv.txt

--- a/buildroot-external/board/odroid-n2/boot.cmd
+++ b/buildroot-external/board/odroid-n2/boot.cmd
@@ -18,10 +18,8 @@ if test -e ${devtype} ${devnum}:${rootfs} /zImage; then
   setenv kernel_img /zImage
   setenv kernel_bootcmd bootz
 else
-  if test -e ${devtype} ${devnum}:${rootfs} /Image; then
-    setenv kernel_img /Image
-    setenv kernel_bootcmd booti
-  fi
+  setenv kernel_img /Image
+  setenv kernel_bootcmd booti
 fi
 
 # import environment from /boot/bootEnv.txt

--- a/buildroot-external/board/odroid-n2/boot.cmd
+++ b/buildroot-external/board/odroid-n2/boot.cmd
@@ -14,6 +14,11 @@ setenv usbstoragequirks "0x2537:0x1066:u,0x2537:0x1068:u"
 
 echo "Boot script loaded from ${devtype} ${devnum}"
 
+# test if the kernel does not exist and if not we use zImage
+if test ! -e ${devtype} ${devnum}:${rootfs} /${kernel_img}; then
+  setenv kernel_img "z${kernel_img}"
+fi
+
 # import environment from /boot/bootEnv.txt
 if test -e ${devtype} ${devnum}:${bootfs} bootEnv.txt; then
   load ${devtype} ${devnum}:${bootfs} ${load_addr} bootEnv.txt
@@ -23,7 +28,9 @@ fi
 # test if the gpio button is 0 (pressed) or if .recoveryMode exists in userfs
 # or if Image doesn't exist in the root partition
 gpio input ${gpio_button}
-if test $? -eq 0 -o -e ${devtype} ${devnum}:${userfs} /.recoveryMode -o ! -e ${devtype} ${devnum}:${rootfs} ${kernel_img}; then
+if test $? -eq 0 \
+   -o -e ${devtype} ${devnum}:${userfs} /.recoveryMode \
+   -o ! -e ${devtype} ${devnum}:${rootfs} /${kernel_img}; then
   echo "==== STARTING RECOVERY SYSTEM ===="
   # load the initrd file
   load ${devtype} ${devnum}:${bootfs} ${ramdisk_addr_r} ${recoveryfs_initrd}

--- a/buildroot-external/board/odroid-n2/boot.cmd
+++ b/buildroot-external/board/odroid-n2/boot.cmd
@@ -7,16 +7,21 @@ setenv rootfs 2
 setenv userfs 3
 #setenv gpio_button "61" # pin 32 (GPIOA_12)
 setenv gpio_button "disabled"
-setenv kernel_img "Image"
 setenv recoveryfs_initrd "recoveryfs-initrd"
 setenv overlays ""
 setenv usbstoragequirks "0x2537:0x1066:u,0x2537:0x1068:u"
 
 echo "Boot script loaded from ${devtype} ${devnum}"
 
-# test if the kernel does not exist and if not we use zImage
-if test ! -e ${devtype} ${devnum}:${rootfs} /${kernel_img}; then
-  setenv kernel_img "z${kernel_img}"
+# decide kernel image on rootfs
+if test -e ${devtype} ${devnum}:${rootfs} /zImage; then
+  setenv kernel_img /zImage
+  setenv kernel_bootcmd bootz
+else
+  if test -e ${devtype} ${devnum}:${rootfs} /Image; then
+    setenv kernel_img /Image
+    setenv kernel_bootcmd booti
+  fi
 fi
 
 # import environment from /boot/bootEnv.txt
@@ -30,13 +35,14 @@ fi
 gpio input ${gpio_button}
 if test $? -eq 0 \
    -o -e ${devtype} ${devnum}:${userfs} /.recoveryMode \
-   -o ! -e ${devtype} ${devnum}:${rootfs} /${kernel_img}; then
+   -o ! -e ${devtype} ${devnum}:${rootfs} ${kernel_img}; then
   echo "==== STARTING RECOVERY SYSTEM ===="
   # load the initrd file
   load ${devtype} ${devnum}:${bootfs} ${ramdisk_addr_r} ${recoveryfs_initrd}
   setenv rootfs_str "/dev/ram0"
   setenv initrd_addr_r ${ramdisk_addr_r}
-  setenv kernel_img "recoveryfs-Image"
+  setenv kernel_img "/recoveryfs-Image"
+  setenv kernel_bootcmd booti
   setenv kernelfs ${bootfs}
 else
   echo "==== NORMAL BOOT ===="
@@ -81,7 +87,7 @@ setenv bootargs "console=${console} root=${rootfs_str} ro rootfstype=ext4 fsck.r
 load ${devtype} ${devnum}:${kernelfs} ${kernel_addr_r} ${kernel_img}
 
 # boot kernel
-booti ${kernel_addr_r} ${initrd_addr_r} ${fdt_addr_r}
+${kernel_bootcmd} ${kernel_addr_r} ${initrd_addr_r} ${fdt_addr_r}
 
 echo "Boot failed, resetting..."
 reset

--- a/buildroot-external/board/rpi0/boot.cmd
+++ b/buildroot-external/board/rpi0/boot.cmd
@@ -7,13 +7,18 @@ setenv bootfs 1
 setenv rootfs 2
 setenv userfs 3
 setenv gpio_button "GPIO24"
-setenv kernel_img "zImage"
+setenv kernel_img "Image"
 setenv recoveryfs_initrd "recoveryfs-initrd"
 setenv usbstoragequirks "174c:55aa:u,2109:0715:u,152d:0578:u,152d:0579:u,152d:1561:u,174c:0829:u,14b0:0206:u,174c:225c:u,7825:a2a4:u,152d:0562:u,125f:a88a:u,152d:a583:u"
 
 # output where we are booting from
 itest.b ${devnum} == 0 && echo "U-boot loaded from SD"
 itest.b ${devnum} == 1 && echo "U-boot loaded from eMMC"
+
+# test if the kernel does not exist and if not we use zImage
+if test ! -e ${devtype} ${devnum}:${rootfs} /${kernel_img}; then
+  setenv kernel_img "z${kernel_img}"
+fi
 
 # import environment from /boot/bootEnv.txt
 if test -e ${devtype} ${devnum}:${bootfs} bootEnv.txt; then
@@ -24,7 +29,9 @@ fi
 # test if the gpio button is 0 (pressed) or if .recoveryMode exists in userfs
 # or if zImage doesn't exist in the root partition
 gpio input ${gpio_button}
-if test $? -eq 0 -o -e ${devtype} ${devnum}:${userfs} /.recoveryMode -o ! -e ${devtype} ${devnum}:${rootfs} ${kernel_img}; then
+if test $? -eq 0 \
+   -o -e ${devtype} ${devnum}:${userfs} /.recoveryMode \
+   -o ! -e ${devtype} ${devnum}:${rootfs} /${kernel_img}; then
   echo "==== STARTING RECOVERY SYSTEM ===="
   # load the initrd file
   load ${devtype} ${devnum}:${bootfs} ${load_addr} ${recoveryfs_initrd}

--- a/buildroot-external/board/rpi0/boot.cmd
+++ b/buildroot-external/board/rpi0/boot.cmd
@@ -7,7 +7,6 @@ setenv bootfs 1
 setenv rootfs 2
 setenv userfs 3
 setenv gpio_button "GPIO24"
-setenv kernel_img "Image"
 setenv recoveryfs_initrd "recoveryfs-initrd"
 setenv usbstoragequirks "174c:55aa:u,2109:0715:u,152d:0578:u,152d:0579:u,152d:1561:u,174c:0829:u,14b0:0206:u,174c:225c:u,7825:a2a4:u,152d:0562:u,125f:a88a:u,152d:a583:u"
 
@@ -15,9 +14,15 @@ setenv usbstoragequirks "174c:55aa:u,2109:0715:u,152d:0578:u,152d:0579:u,152d:15
 itest.b ${devnum} == 0 && echo "U-boot loaded from SD"
 itest.b ${devnum} == 1 && echo "U-boot loaded from eMMC"
 
-# test if the kernel does not exist and if not we use zImage
-if test ! -e ${devtype} ${devnum}:${rootfs} /${kernel_img}; then
-  setenv kernel_img "z${kernel_img}"
+# decide kernel image on rootfs
+if test -e ${devtype} ${devnum}:${rootfs} /zImage; then
+  setenv kernel_img /zImage
+  setenv kernel_bootcmd bootz
+else
+  if test -e ${devtype} ${devnum}:${rootfs} /Image; then
+    setenv kernel_img /Image
+    setenv kernel_bootcmd booti
+  fi
 fi
 
 # import environment from /boot/bootEnv.txt
@@ -31,13 +36,14 @@ fi
 gpio input ${gpio_button}
 if test $? -eq 0 \
    -o -e ${devtype} ${devnum}:${userfs} /.recoveryMode \
-   -o ! -e ${devtype} ${devnum}:${rootfs} /${kernel_img}; then
+   -o ! -e ${devtype} ${devnum}:${rootfs} ${kernel_img}; then
   echo "==== STARTING RECOVERY SYSTEM ===="
   # load the initrd file
   load ${devtype} ${devnum}:${bootfs} ${load_addr} ${recoveryfs_initrd}
   setenv rootfs_str "/dev/ram0"
   setenv initrd_addr_r ${load_addr}
-  setenv kernel_img "recoveryfs-zImage"
+  setenv kernel_img "/recoveryfs-zImage"
+  setenv kernel_bootcmd bootz
   setenv kernelfs ${bootfs}
 else
   echo "==== NORMAL BOOT ===="
@@ -59,7 +65,7 @@ setenv bootargs "dwc_otg.lpm_enable=0 sdhci_bcm2708.enable_llm=0 console=${conso
 load ${devtype} ${devnum}:${kernelfs} ${kernel_addr_r} ${kernel_img}
 
 # boot kernel
-bootz ${kernel_addr_r} ${initrd_addr_r} ${fdt_addr}
+${kernel_bootcmd} ${kernel_addr_r} ${initrd_addr_r} ${fdt_addr}
 
 echo "Boot failed, resetting..."
 reset

--- a/buildroot-external/board/rpi0/boot.cmd
+++ b/buildroot-external/board/rpi0/boot.cmd
@@ -19,10 +19,8 @@ if test -e ${devtype} ${devnum}:${rootfs} /zImage; then
   setenv kernel_img /zImage
   setenv kernel_bootcmd bootz
 else
-  if test -e ${devtype} ${devnum}:${rootfs} /Image; then
-    setenv kernel_img /Image
-    setenv kernel_bootcmd booti
-  fi
+  setenv kernel_img /Image
+  setenv kernel_bootcmd booti
 fi
 
 # import environment from /boot/bootEnv.txt

--- a/buildroot-external/board/rpi2/boot.cmd
+++ b/buildroot-external/board/rpi2/boot.cmd
@@ -19,10 +19,8 @@ if test -e ${devtype} ${devnum}:${rootfs} /zImage; then
   setenv kernel_img /zImage
   setenv kernel_bootcmd bootz
 else
-  if test -e ${devtype} ${devnum}:${rootfs} /Image; then
-    setenv kernel_img /Image
-    setenv kernel_bootcmd booti
-  fi
+  setenv kernel_img /Image
+  setenv kernel_bootcmd booti
 fi
 
 # import environment from /boot/bootEnv.txt

--- a/buildroot-external/board/rpi2/boot.cmd
+++ b/buildroot-external/board/rpi2/boot.cmd
@@ -7,7 +7,6 @@ setenv bootfs 1
 setenv rootfs 2
 setenv userfs 3
 setenv gpio_button "GPIO12"
-setenv kernel_img "Image"
 setenv recoveryfs_initrd "recoveryfs-initrd"
 setenv usbstoragequirks "174c:55aa:u,2109:0715:u,152d:0578:u,152d:0579:u,152d:1561:u,174c:0829:u,14b0:0206:u,174c:225c:u,7825:a2a4:u,152d:0562:u,125f:a88a:u,152d:a583:u"
 
@@ -15,9 +14,15 @@ setenv usbstoragequirks "174c:55aa:u,2109:0715:u,152d:0578:u,152d:0579:u,152d:15
 itest.b ${devnum} == 0 && echo "U-boot loaded from SD"
 itest.b ${devnum} == 1 && echo "U-boot loaded from eMMC"
 
-# test if the kernel does not exist and if not we use zImage
-if test ! -e ${devtype} ${devnum}:${rootfs} /${kernel_img}; then
-  setenv kernel_img "z${kernel_img}"
+# decide kernel image on rootfs
+if test -e ${devtype} ${devnum}:${rootfs} /zImage; then
+  setenv kernel_img /zImage
+  setenv kernel_bootcmd bootz
+else
+  if test -e ${devtype} ${devnum}:${rootfs} /Image; then
+    setenv kernel_img /Image
+    setenv kernel_bootcmd booti
+  fi
 fi
 
 # import environment from /boot/bootEnv.txt
@@ -31,13 +36,14 @@ fi
 gpio input ${gpio_button}
 if test $? -eq 0 \
    -o -e ${devtype} ${devnum}:${userfs} /.recoveryMode \
-   -o ! -e ${devtype} ${devnum}:${rootfs} /${kernel_img}; then
+   -o ! -e ${devtype} ${devnum}:${rootfs} ${kernel_img}; then
   echo "==== STARTING RECOVERY SYSTEM ===="
   # load the initrd file
   load ${devtype} ${devnum}:${bootfs} ${load_addr} ${recoveryfs_initrd}
   setenv rootfs_str "/dev/ram0"
   setenv initrd_addr_r ${load_addr}
-  setenv kernel_img "recoveryfs-zImage"
+  setenv kernel_img "/recoveryfs-zImage"
+  setenv kernel_bootcmd bootz
   setenv kernelfs ${bootfs}
 else
   echo "==== NORMAL BOOT ===="
@@ -59,7 +65,7 @@ setenv bootargs "dwc_otg.lpm_enable=0 sdhci_bcm2708.enable_llm=0 console=${conso
 load ${devtype} ${devnum}:${kernelfs} ${kernel_addr_r} ${kernel_img}
 
 # boot kernel
-bootz ${kernel_addr_r} ${initrd_addr_r} ${fdt_addr}
+${kernel_bootcmd} ${kernel_addr_r} ${initrd_addr_r} ${fdt_addr}
 
 echo "Boot failed, resetting..."
 reset

--- a/buildroot-external/board/rpi2/boot.cmd
+++ b/buildroot-external/board/rpi2/boot.cmd
@@ -7,13 +7,18 @@ setenv bootfs 1
 setenv rootfs 2
 setenv userfs 3
 setenv gpio_button "GPIO12"
-setenv kernel_img "zImage"
+setenv kernel_img "Image"
 setenv recoveryfs_initrd "recoveryfs-initrd"
 setenv usbstoragequirks "174c:55aa:u,2109:0715:u,152d:0578:u,152d:0579:u,152d:1561:u,174c:0829:u,14b0:0206:u,174c:225c:u,7825:a2a4:u,152d:0562:u,125f:a88a:u,152d:a583:u"
 
 # output where we are booting from
 itest.b ${devnum} == 0 && echo "U-boot loaded from SD"
 itest.b ${devnum} == 1 && echo "U-boot loaded from eMMC"
+
+# test if the kernel does not exist and if not we use zImage
+if test ! -e ${devtype} ${devnum}:${rootfs} /${kernel_img}; then
+  setenv kernel_img "z${kernel_img}"
+fi
 
 # import environment from /boot/bootEnv.txt
 if test -e ${devtype} ${devnum}:${bootfs} bootEnv.txt; then
@@ -24,7 +29,9 @@ fi
 # test if the gpio button is 0 (pressed) or if .recoveryMode exists in userfs
 # or if zImage doesn't exist in the root partition
 gpio input ${gpio_button}
-if test $? -eq 0 -o -e ${devtype} ${devnum}:${userfs} /.recoveryMode -o ! -e ${devtype} ${devnum}:${rootfs} ${kernel_img}; then
+if test $? -eq 0 \
+   -o -e ${devtype} ${devnum}:${userfs} /.recoveryMode \
+   -o ! -e ${devtype} ${devnum}:${rootfs} /${kernel_img}; then
   echo "==== STARTING RECOVERY SYSTEM ===="
   # load the initrd file
   load ${devtype} ${devnum}:${bootfs} ${load_addr} ${recoveryfs_initrd}

--- a/buildroot-external/board/rpi3/boot.cmd
+++ b/buildroot-external/board/rpi3/boot.cmd
@@ -15,14 +15,12 @@ itest.b ${devnum} == 0 && echo "U-boot loaded from SD"
 itest.b ${devnum} == 1 && echo "U-boot loaded from eMMC"
 
 # decide kernel image on rootfs
-if test -e ${devtype} ${devnum}:${rootfs} /zImage; then
+if test -e ${devtype} ${devnum}:${rootfs} /Image; then
+  setenv kernel_img /Image
+  setenv kernel_bootcmd booti
+else
   setenv kernel_img /zImage
   setenv kernel_bootcmd bootz
-else
-  if test -e ${devtype} ${devnum}:${rootfs} /Image; then
-    setenv kernel_img /Image
-    setenv kernel_bootcmd booti
-  fi
 fi
 
 # import environment from /boot/bootEnv.txt

--- a/buildroot-external/board/rpi3/boot.cmd
+++ b/buildroot-external/board/rpi3/boot.cmd
@@ -15,6 +15,11 @@ setenv usbstoragequirks "174c:55aa:u,2109:0715:u,152d:0578:u,152d:0579:u,152d:15
 itest.b ${devnum} == 0 && echo "U-boot loaded from SD"
 itest.b ${devnum} == 1 && echo "U-boot loaded from eMMC"
 
+# test if the kernel does not exist and if not we use zImage
+if test ! -e ${devtype} ${devnum}:${rootfs} /${kernel_img}; then
+  setenv kernel_img "z${kernel_img}"
+fi
+
 # import environment from /boot/bootEnv.txt
 if test -e ${devtype} ${devnum}:${bootfs} bootEnv.txt; then
   load ${devtype} ${devnum}:${bootfs} ${load_addr} bootEnv.txt
@@ -24,7 +29,9 @@ fi
 # test if the gpio button is 0 (pressed) or if .recoveryMode exists in userfs
 # or if Image doesn't exist in the root partition
 gpio input ${gpio_button}
-if test $? -eq 0 -o -e ${devtype} ${devnum}:${userfs} /.recoveryMode -o ! -e ${devtype} ${devnum}:${rootfs} ${kernel_img}; then
+if test $? -eq 0 \
+   -o -e ${devtype} ${devnum}:${userfs} /.recoveryMode \
+   -o ! -e ${devtype} ${devnum}:${rootfs} /${kernel_img}; then
   echo "==== STARTING RECOVERY SYSTEM ===="
   # load the initrd file
   load ${devtype} ${devnum}:${bootfs} ${load_addr} ${recoveryfs_initrd}

--- a/buildroot-external/board/rpi3/boot.cmd
+++ b/buildroot-external/board/rpi3/boot.cmd
@@ -7,7 +7,6 @@ setenv bootfs 1
 setenv rootfs 2
 setenv userfs 3
 setenv gpio_button "GPIO12"
-setenv kernel_img "Image"
 setenv recoveryfs_initrd "recoveryfs-initrd"
 setenv usbstoragequirks "174c:55aa:u,2109:0715:u,152d:0578:u,152d:0579:u,152d:1561:u,174c:0829:u,14b0:0206:u,174c:225c:u,7825:a2a4:u,152d:0562:u,125f:a88a:u,152d:a583:u"
 
@@ -15,9 +14,15 @@ setenv usbstoragequirks "174c:55aa:u,2109:0715:u,152d:0578:u,152d:0579:u,152d:15
 itest.b ${devnum} == 0 && echo "U-boot loaded from SD"
 itest.b ${devnum} == 1 && echo "U-boot loaded from eMMC"
 
-# test if the kernel does not exist and if not we use zImage
-if test ! -e ${devtype} ${devnum}:${rootfs} /${kernel_img}; then
-  setenv kernel_img "z${kernel_img}"
+# decide kernel image on rootfs
+if test -e ${devtype} ${devnum}:${rootfs} /zImage; then
+  setenv kernel_img /zImage
+  setenv kernel_bootcmd bootz
+else
+  if test -e ${devtype} ${devnum}:${rootfs} /Image; then
+    setenv kernel_img /Image
+    setenv kernel_bootcmd booti
+  fi
 fi
 
 # import environment from /boot/bootEnv.txt
@@ -31,13 +36,14 @@ fi
 gpio input ${gpio_button}
 if test $? -eq 0 \
    -o -e ${devtype} ${devnum}:${userfs} /.recoveryMode \
-   -o ! -e ${devtype} ${devnum}:${rootfs} /${kernel_img}; then
+   -o ! -e ${devtype} ${devnum}:${rootfs} ${kernel_img}; then
   echo "==== STARTING RECOVERY SYSTEM ===="
   # load the initrd file
   load ${devtype} ${devnum}:${bootfs} ${load_addr} ${recoveryfs_initrd}
   setenv rootfs_str "/dev/ram0"
   setenv initrd_addr_r ${load_addr}
-  setenv kernel_img "recoveryfs-Image"
+  setenv kernel_img "/recoveryfs-Image"
+  setenv kernel_bootcmd booti
   setenv kernelfs ${bootfs}
 else
   echo "==== NORMAL BOOT ===="
@@ -59,7 +65,7 @@ setenv bootargs "dwc_otg.lpm_enable=0 sdhci_bcm2708.enable_llm=0 console=${conso
 load ${devtype} ${devnum}:${kernelfs} ${kernel_addr_r} ${kernel_img}
 
 # boot kernel
-booti ${kernel_addr_r} ${initrd_addr_r} ${fdt_addr}
+${kernel_bootcmd} ${kernel_addr_r} ${initrd_addr_r} ${fdt_addr}
 
 echo "Boot failed, resetting..."
 reset

--- a/buildroot-external/board/rpi4/boot.cmd
+++ b/buildroot-external/board/rpi4/boot.cmd
@@ -15,14 +15,12 @@ itest.b ${devnum} == 0 && echo "U-boot loaded from SD"
 itest.b ${devnum} == 1 && echo "U-boot loaded from eMMC"
 
 # decide kernel image on rootfs
-if test -e ${devtype} ${devnum}:${rootfs} /zImage; then
+if test -e ${devtype} ${devnum}:${rootfs} /Image; then
+  setenv kernel_img /Image
+  setenv kernel_bootcmd booti
+else
   setenv kernel_img /zImage
   setenv kernel_bootcmd bootz
-else
-  if test -e ${devtype} ${devnum}:${rootfs} /Image; then
-    setenv kernel_img /Image
-    setenv kernel_bootcmd booti
-  fi
 fi
 
 # import environment from /boot/bootEnv.txt

--- a/buildroot-external/board/rpi4/boot.cmd
+++ b/buildroot-external/board/rpi4/boot.cmd
@@ -15,6 +15,11 @@ setenv usbstoragequirks "174c:55aa:u,2109:0715:u,152d:0578:u,152d:0579:u,152d:15
 itest.b ${devnum} == 0 && echo "U-boot loaded from SD"
 itest.b ${devnum} == 1 && echo "U-boot loaded from eMMC"
 
+# test if the kernel does not exist and if not we use zImage
+if test ! -e ${devtype} ${devnum}:${rootfs} /${kernel_img}; then
+  setenv kernel_img "z${kernel_img}"
+fi
+
 # import environment from /boot/bootEnv.txt
 if test -e ${devtype} ${devnum}:${bootfs} bootEnv.txt; then
   load ${devtype} ${devnum}:${bootfs} ${load_addr} bootEnv.txt
@@ -24,7 +29,9 @@ fi
 # test if the gpio button is 0 (pressed) or if .recoveryMode exists in userfs
 # or if Image doesn't exist in the root partition
 gpio input ${gpio_button}
-if test $? -eq 0 -o -e ${devtype} ${devnum}:${userfs} /.recoveryMode -o ! -e ${devtype} ${devnum}:${rootfs} ${kernel_img}; then
+if test $? -eq 0 \
+   -o -e ${devtype} ${devnum}:${userfs} /.recoveryMode \
+   -o ! -e ${devtype} ${devnum}:${rootfs} /${kernel_img}; then
   echo "==== STARTING RECOVERY SYSTEM ===="
   # load the initrd file
   load ${devtype} ${devnum}:${bootfs} ${load_addr} ${recoveryfs_initrd}

--- a/buildroot-external/board/rpi4/boot.cmd
+++ b/buildroot-external/board/rpi4/boot.cmd
@@ -7,7 +7,6 @@ setenv bootfs 1
 setenv rootfs 2
 setenv userfs 3
 setenv gpio_button "GPIO12"
-setenv kernel_img "Image"
 setenv recoveryfs_initrd "recoveryfs-initrd"
 setenv usbstoragequirks "174c:55aa:u,2109:0715:u,152d:0578:u,152d:0579:u,152d:1561:u,174c:0829:u,14b0:0206:u,174c:225c:u,7825:a2a4:u,152d:0562:u,125f:a88a:u,152d:a583:u"
 
@@ -15,9 +14,15 @@ setenv usbstoragequirks "174c:55aa:u,2109:0715:u,152d:0578:u,152d:0579:u,152d:15
 itest.b ${devnum} == 0 && echo "U-boot loaded from SD"
 itest.b ${devnum} == 1 && echo "U-boot loaded from eMMC"
 
-# test if the kernel does not exist and if not we use zImage
-if test ! -e ${devtype} ${devnum}:${rootfs} /${kernel_img}; then
-  setenv kernel_img "z${kernel_img}"
+# decide kernel image on rootfs
+if test -e ${devtype} ${devnum}:${rootfs} /zImage; then
+  setenv kernel_img /zImage
+  setenv kernel_bootcmd bootz
+else
+  if test -e ${devtype} ${devnum}:${rootfs} /Image; then
+    setenv kernel_img /Image
+    setenv kernel_bootcmd booti
+  fi
 fi
 
 # import environment from /boot/bootEnv.txt
@@ -31,13 +36,14 @@ fi
 gpio input ${gpio_button}
 if test $? -eq 0 \
    -o -e ${devtype} ${devnum}:${userfs} /.recoveryMode \
-   -o ! -e ${devtype} ${devnum}:${rootfs} /${kernel_img}; then
+   -o ! -e ${devtype} ${devnum}:${rootfs} ${kernel_img}; then
   echo "==== STARTING RECOVERY SYSTEM ===="
   # load the initrd file
   load ${devtype} ${devnum}:${bootfs} ${load_addr} ${recoveryfs_initrd}
   setenv rootfs_str "/dev/ram0"
   setenv initrd_addr_r ${load_addr}
-  setenv kernel_img "recoveryfs-Image"
+  setenv kernel_img "/recoveryfs-Image"
+  setenv kernel_bootcmd booti
   setenv kernelfs ${bootfs}
 else
   echo "==== NORMAL BOOT ===="
@@ -59,7 +65,7 @@ setenv bootargs "dwc_otg.lpm_enable=0 sdhci_bcm2708.enable_llm=0 console=${conso
 load ${devtype} ${devnum}:${kernelfs} ${kernel_addr_r} ${kernel_img}
 
 # boot kernel
-booti ${kernel_addr_r} ${initrd_addr_r} ${fdt_addr}
+${kernel_bootcmd} ${kernel_addr_r} ${initrd_addr_r} ${fdt_addr}
 
 echo "Boot failed, resetting..."
 reset

--- a/buildroot-external/board/rpi5/boot.cmd
+++ b/buildroot-external/board/rpi5/boot.cmd
@@ -7,7 +7,6 @@ setenv bootfs 1
 setenv rootfs 2
 setenv userfs 3
 setenv gpio_button "GPIO12"
-setenv kernel_img "Image"
 setenv recoveryfs_initrd "recoveryfs-initrd"
 setenv usbstoragequirks "174c:55aa:u,2109:0715:u,152d:0578:u,152d:0579:u,152d:1561:u,174c:0829:u,14b0:0206:u,174c:225c:u,7825:a2a4:u,152d:0562:u,125f:a88a:u,152d:a583:u"
 
@@ -15,11 +14,17 @@ setenv usbstoragequirks "174c:55aa:u,2109:0715:u,152d:0578:u,152d:0579:u,152d:15
 itest.b ${devnum} == 0 && echo "U-boot loaded from SD"
 itest.b ${devnum} == 1 && echo "U-boot loaded from eMMC"
 
-# test if the kernel does not exist and if not we use zImage
-if test ! -e ${devtype} ${devnum}:${rootfs} /${kernel_img}; then
-  setenv kernel_img "z${kernel_img}"
+# decide kernel image on rootfs
+if test -e ${devtype} ${devnum}:${rootfs} /zImage; then
+  setenv kernel_img /zImage
+  setenv kernel_bootcmd bootz
+else
+  if test -e ${devtype} ${devnum}:${rootfs} /Image; then
+    setenv kernel_img /Image
+    setenv kernel_bootcmd booti
+  fi
 fi
-
+ 
 # import environment from /boot/bootEnv.txt
 if test -e ${devtype} ${devnum}:${bootfs} bootEnv.txt; then
   load ${devtype} ${devnum}:${bootfs} ${load_addr} bootEnv.txt
@@ -31,13 +36,14 @@ fi
 gpio input ${gpio_button}
 if test $? -eq 0 \
    -o -e ${devtype} ${devnum}:${userfs} /.recoveryMode \
-   -o ! -e ${devtype} ${devnum}:${rootfs} /${kernel_img}; then
+   -o ! -e ${devtype} ${devnum}:${rootfs} ${kernel_img}; then
   echo "==== STARTING RECOVERY SYSTEM ===="
   # load the initrd file
   load ${devtype} ${devnum}:${bootfs} ${load_addr} ${recoveryfs_initrd}
   setenv rootfs_str "/dev/ram0"
   setenv initrd_addr_r ${load_addr}
-  setenv kernel_img "recoveryfs-Image"
+  setenv kernel_img "/recoveryfs-Image"
+  setenv kernel_bootcmd booti
   setenv kernelfs ${bootfs}
 else
   echo "==== NORMAL BOOT ===="
@@ -59,7 +65,7 @@ setenv bootargs "dwc_otg.lpm_enable=0 sdhci_bcm2708.enable_llm=0 console=${conso
 load ${devtype} ${devnum}:${kernelfs} ${kernel_addr_r} ${kernel_img}
 
 # boot kernel
-booti ${kernel_addr_r} ${initrd_addr_r} ${fdt_addr}
+${kernel_bootcmd} ${kernel_addr_r} ${initrd_addr_r} ${fdt_addr}
 
 echo "Boot failed, resetting..."
 reset

--- a/buildroot-external/board/rpi5/boot.cmd
+++ b/buildroot-external/board/rpi5/boot.cmd
@@ -15,6 +15,11 @@ setenv usbstoragequirks "174c:55aa:u,2109:0715:u,152d:0578:u,152d:0579:u,152d:15
 itest.b ${devnum} == 0 && echo "U-boot loaded from SD"
 itest.b ${devnum} == 1 && echo "U-boot loaded from eMMC"
 
+# test if the kernel does not exist and if not we use zImage
+if test ! -e ${devtype} ${devnum}:${rootfs} /${kernel_img}; then
+  setenv kernel_img "z${kernel_img}"
+fi
+
 # import environment from /boot/bootEnv.txt
 if test -e ${devtype} ${devnum}:${bootfs} bootEnv.txt; then
   load ${devtype} ${devnum}:${bootfs} ${load_addr} bootEnv.txt
@@ -24,7 +29,9 @@ fi
 # test if the gpio button is 0 (pressed) or if .recoveryMode exists in userfs
 # or if Image doesn't exist in the root partition
 gpio input ${gpio_button}
-if test $? -eq 0 -o -e ${devtype} ${devnum}:${userfs} /.recoveryMode -o ! -e ${devtype} ${devnum}:${rootfs} ${kernel_img}; then
+if test $? -eq 0 \
+   -o -e ${devtype} ${devnum}:${userfs} /.recoveryMode \
+   -o ! -e ${devtype} ${devnum}:${rootfs} /${kernel_img}; then
   echo "==== STARTING RECOVERY SYSTEM ===="
   # load the initrd file
   load ${devtype} ${devnum}:${bootfs} ${load_addr} ${recoveryfs_initrd}

--- a/buildroot-external/board/rpi5/boot.cmd
+++ b/buildroot-external/board/rpi5/boot.cmd
@@ -15,14 +15,12 @@ itest.b ${devnum} == 0 && echo "U-boot loaded from SD"
 itest.b ${devnum} == 1 && echo "U-boot loaded from eMMC"
 
 # decide kernel image on rootfs
-if test -e ${devtype} ${devnum}:${rootfs} /zImage; then
+if test -e ${devtype} ${devnum}:${rootfs} /Image; then
+  setenv kernel_img /Image
+  setenv kernel_bootcmd booti
+else
   setenv kernel_img /zImage
   setenv kernel_bootcmd bootz
-else
-  if test -e ${devtype} ${devnum}:${rootfs} /Image; then
-    setenv kernel_img /Image
-    setenv kernel_bootcmd booti
-  fi
 fi
  
 # import environment from /boot/bootEnv.txt

--- a/buildroot-external/board/tinkerboard/boot.cmd
+++ b/buildroot-external/board/tinkerboard/boot.cmd
@@ -18,10 +18,8 @@ if test -e ${devtype} ${devnum}:${rootfs} /zImage; then
   setenv kernel_img /zImage
   setenv kernel_bootcmd bootz
 else
-  if test -e ${devtype} ${devnum}:${rootfs} /Image; then
-    setenv kernel_img /Image
-    setenv kernel_bootcmd booti
-  fi
+  setenv kernel_img /Image
+  setenv kernel_bootcmd booti
 fi
 
 # import environment from /boot/bootEnv.txt

--- a/buildroot-external/board/tinkerboard/boot.cmd
+++ b/buildroot-external/board/tinkerboard/boot.cmd
@@ -7,12 +7,17 @@ setenv bootfs 1
 setenv rootfs 2
 setenv userfs 3
 setenv gpio_button "H23" # matches GPIO239
-setenv kernel_img "zImage"
+setenv kernel_img "Image"
 setenv recoveryfs_initrd "recoveryfs-initrd"
 setenv overlays ""
 setenv usbstoragequirks "0x2537:0x1066:u,0x2537:0x1068:u"
 
 echo "Boot script loaded from ${devtype} ${devnum}"
+
+# test if the kernel does not exist and if not we use zImage
+if test ! -e ${devtype} ${devnum}:${rootfs} /${kernel_img}; then
+  setenv kernel_img "z${kernel_img}"
+fi
 
 # import environment from /boot/bootEnv.txt
 if test -e ${devtype} ${devnum}:${bootfs} bootEnv.txt; then
@@ -23,7 +28,9 @@ fi
 # test if the gpio button is 0 (pressed) or if .recoveryMode exists in userfs
 # or if zImage doesn't exist in the root partition
 gpio input ${gpio_button}
-if test $? -eq 0 -o -e ${devtype} ${devnum}:${userfs} /.recoveryMode -o ! -e ${devtype} ${devnum}:${rootfs} ${kernel_img}; then
+if test $? -eq 0 \
+   -o -e ${devtype} ${devnum}:${userfs} /.recoveryMode \
+   -o ! -e ${devtype} ${devnum}:${rootfs} /${kernel_img}; then
   echo "==== STARTING RECOVERY SYSTEM ===="
   # load the initrd file
   load ${devtype} ${devnum}:${bootfs} ${ramdisk_addr_r} ${recoveryfs_initrd}


### PR DESCRIPTION
This change fixes potential issues with rootfs systems still containing "zImage" type files. For these systems the recovery system was always started, which prevented correct rootfs startup. This should fix issues when trying to downgrade to older/previous releases as well as downgrading to the legacy CCU3 firmware releases in future.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime selection of kernel image and boot method across multiple boards.
  * Import of boot environment variables during boot.
  * Boot invocation now uses a runtime-determined boot helper.

* **Bug Fixes**
  * Recovery and fallback handling preserved and made more reliable when rootfs kernel image is absent.
  * Recovery flow uses explicit rootfs paths for recovery images.

* **Refactor**
  * Recovery-condition checks reformatted for readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->