### PR TITLE
potentially fix DEPLOY_KEY usage when running our workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -531,10 +531,10 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          persist-credentials: false
+          ref: master
+          persist-credentials: true
           ssh-key: ${{ secrets.DEPLOY_KEY }}
           fetch-depth: 0
-          ref: master
 
       - name: Bump HomeAssistant add-on version
         run: |
@@ -596,7 +596,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git pull --rebase --autostash
           git diff --quiet || git commit -a -m "release bump [${{ needs.release_draft.outputs.version }}]"
-          git push
+          git push origin HEAD:master
 
   helm:
     permissions:

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -519,10 +519,10 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
-          persist-credentials: false
+          ref: master
+          persist-credentials: true
           ssh-key: ${{ secrets.DEPLOY_KEY }}
           fetch-depth: 0
-          ref: master
 
       - name: Setup Environment
         run: |
@@ -571,7 +571,7 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git pull --rebase --autostash
           git diff --quiet || git commit -a -m "snapshot bump [${{ env.BUILD_VERSION }}-${{ env.GITHUB_SHA7 }}]"
-          git push
+          git push origin HEAD:master
 
   cleanup:
     permissions:


### PR DESCRIPTION
By using "persist-credentials: true" we can potentially fix the recent DEPLOY_KEY uses with our newly protected master branch setup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release and snapshot automation by ensuring checkouts target the master branch and credentials persist during runs.
  * Updated push behavior to explicitly publish to the master branch, streamlining release and snapshot publishing.
  * These changes reduce failures in publish steps and make build outputs more consistently available.
  * No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->