### PR TITLE
partly revert u-boot boot script to fix recoveryMode mode check

### DIFF
--- a/buildroot-external/board/odroid-c4/boot.cmd
+++ b/buildroot-external/board/odroid-c4/boot.cmd
@@ -7,20 +7,13 @@ setenv rootfs 2
 setenv userfs 3
 #setenv gpio_button "23" # pin 32 (GPIOH_7)
 setenv gpio_button "disabled"
+setenv kernel_img /Image
+setenv kernel_bootcmd booti
 setenv recoveryfs_initrd "recoveryfs-initrd"
 setenv overlays ""
 setenv usbstoragequirks "0x2537:0x1066:u,0x2537:0x1068:u"
 
 echo "Boot script loaded from ${devtype} ${devnum}"
-
-# decide kernel image on rootfs
-if test -e ${devtype} ${devnum}:${rootfs} /Image; then
-  setenv kernel_img /Image
-  setenv kernel_bootcmd booti
-else
-  setenv kernel_img /zImage
-  setenv kernel_bootcmd bootz
-fi
 
 # import environment from /boot/bootEnv.txt
 if test -e ${devtype} ${devnum}:${bootfs} bootEnv.txt; then
@@ -31,9 +24,7 @@ fi
 # test if the gpio button is 0 (pressed) or if .recoveryMode exists in userfs
 # or if Image doesn't exist in the root partition
 gpio input ${gpio_button}
-if test $? -eq 0 \
-   -o -e ${devtype} ${devnum}:${userfs} /.recoveryMode \
-   -o ! -e ${devtype} ${devnum}:${rootfs} ${kernel_img}; then
+if test $? -eq 0 -o -e ${devtype} ${devnum}:${userfs} /.recoveryMode -o ! -e ${devtype} ${devnum}:${rootfs} ${kernel_img}; then
   echo "==== STARTING RECOVERY SYSTEM ===="
   # load the initrd file
   load ${devtype} ${devnum}:${bootfs} ${ramdisk_addr_r} ${recoveryfs_initrd}

--- a/buildroot-external/board/odroid-n2/boot.cmd
+++ b/buildroot-external/board/odroid-n2/boot.cmd
@@ -7,20 +7,13 @@ setenv rootfs 2
 setenv userfs 3
 #setenv gpio_button "61" # pin 32 (GPIOA_12)
 setenv gpio_button "disabled"
+setenv kernel_img /Image
+setenv kernel_bootcmd booti
 setenv recoveryfs_initrd "recoveryfs-initrd"
 setenv overlays ""
 setenv usbstoragequirks "0x2537:0x1066:u,0x2537:0x1068:u"
 
 echo "Boot script loaded from ${devtype} ${devnum}"
-
-# decide kernel image on rootfs
-if test -e ${devtype} ${devnum}:${rootfs} /zImage; then
-  setenv kernel_img /zImage
-  setenv kernel_bootcmd bootz
-else
-  setenv kernel_img /Image
-  setenv kernel_bootcmd booti
-fi
 
 # import environment from /boot/bootEnv.txt
 if test -e ${devtype} ${devnum}:${bootfs} bootEnv.txt; then
@@ -31,9 +24,7 @@ fi
 # test if the gpio button is 0 (pressed) or if .recoveryMode exists in userfs
 # or if Image doesn't exist in the root partition
 gpio input ${gpio_button}
-if test $? -eq 0 \
-   -o -e ${devtype} ${devnum}:${userfs} /.recoveryMode \
-   -o ! -e ${devtype} ${devnum}:${rootfs} ${kernel_img}; then
+if test $? -eq 0 -o -e ${devtype} ${devnum}:${userfs} /.recoveryMode -o ! -e ${devtype} ${devnum}:${rootfs} ${kernel_img}; then
   echo "==== STARTING RECOVERY SYSTEM ===="
   # load the initrd file
   load ${devtype} ${devnum}:${bootfs} ${ramdisk_addr_r} ${recoveryfs_initrd}

--- a/buildroot-external/board/rpi0/boot.cmd
+++ b/buildroot-external/board/rpi0/boot.cmd
@@ -7,21 +7,14 @@ setenv bootfs 1
 setenv rootfs 2
 setenv userfs 3
 setenv gpio_button "GPIO24"
+setenv kernel_img /zImage
+setenv kernel_bootcmd bootz
 setenv recoveryfs_initrd "recoveryfs-initrd"
 setenv usbstoragequirks "174c:55aa:u,2109:0715:u,152d:0578:u,152d:0579:u,152d:1561:u,174c:0829:u,14b0:0206:u,174c:225c:u,7825:a2a4:u,152d:0562:u,125f:a88a:u,152d:a583:u"
 
 # output where we are booting from
 itest.b ${devnum} == 0 && echo "U-boot loaded from SD"
 itest.b ${devnum} == 1 && echo "U-boot loaded from eMMC"
-
-# decide kernel image on rootfs
-if test -e ${devtype} ${devnum}:${rootfs} /zImage; then
-  setenv kernel_img /zImage
-  setenv kernel_bootcmd bootz
-else
-  setenv kernel_img /Image
-  setenv kernel_bootcmd booti
-fi
 
 # import environment from /boot/bootEnv.txt
 if test -e ${devtype} ${devnum}:${bootfs} bootEnv.txt; then
@@ -32,9 +25,7 @@ fi
 # test if the gpio button is 0 (pressed) or if .recoveryMode exists in userfs
 # or if zImage doesn't exist in the root partition
 gpio input ${gpio_button}
-if test $? -eq 0 \
-   -o -e ${devtype} ${devnum}:${userfs} /.recoveryMode \
-   -o ! -e ${devtype} ${devnum}:${rootfs} ${kernel_img}; then
+if test $? -eq 0 -o -e ${devtype} ${devnum}:${userfs} /.recoveryMode -o ! -e ${devtype} ${devnum}:${rootfs} ${kernel_img}; then
   echo "==== STARTING RECOVERY SYSTEM ===="
   # load the initrd file
   load ${devtype} ${devnum}:${bootfs} ${load_addr} ${recoveryfs_initrd}

--- a/buildroot-external/board/rpi2/boot.cmd
+++ b/buildroot-external/board/rpi2/boot.cmd
@@ -7,21 +7,14 @@ setenv bootfs 1
 setenv rootfs 2
 setenv userfs 3
 setenv gpio_button "GPIO12"
+setenv kernel_img /zImage
+setenv kernel_bootcmd bootz
 setenv recoveryfs_initrd "recoveryfs-initrd"
 setenv usbstoragequirks "174c:55aa:u,2109:0715:u,152d:0578:u,152d:0579:u,152d:1561:u,174c:0829:u,14b0:0206:u,174c:225c:u,7825:a2a4:u,152d:0562:u,125f:a88a:u,152d:a583:u"
 
 # output where we are booting from
 itest.b ${devnum} == 0 && echo "U-boot loaded from SD"
 itest.b ${devnum} == 1 && echo "U-boot loaded from eMMC"
-
-# decide kernel image on rootfs
-if test -e ${devtype} ${devnum}:${rootfs} /zImage; then
-  setenv kernel_img /zImage
-  setenv kernel_bootcmd bootz
-else
-  setenv kernel_img /Image
-  setenv kernel_bootcmd booti
-fi
 
 # import environment from /boot/bootEnv.txt
 if test -e ${devtype} ${devnum}:${bootfs} bootEnv.txt; then
@@ -32,9 +25,7 @@ fi
 # test if the gpio button is 0 (pressed) or if .recoveryMode exists in userfs
 # or if zImage doesn't exist in the root partition
 gpio input ${gpio_button}
-if test $? -eq 0 \
-   -o -e ${devtype} ${devnum}:${userfs} /.recoveryMode \
-   -o ! -e ${devtype} ${devnum}:${rootfs} ${kernel_img}; then
+if test $? -eq 0 -o -e ${devtype} ${devnum}:${userfs} /.recoveryMode -o ! -e ${devtype} ${devnum}:${rootfs} ${kernel_img}; then
   echo "==== STARTING RECOVERY SYSTEM ===="
   # load the initrd file
   load ${devtype} ${devnum}:${bootfs} ${load_addr} ${recoveryfs_initrd}

--- a/buildroot-external/board/rpi3/boot.cmd
+++ b/buildroot-external/board/rpi3/boot.cmd
@@ -7,21 +7,14 @@ setenv bootfs 1
 setenv rootfs 2
 setenv userfs 3
 setenv gpio_button "GPIO12"
+setenv kernel_img /Image
+setenv kernel_bootcmd booti
 setenv recoveryfs_initrd "recoveryfs-initrd"
 setenv usbstoragequirks "174c:55aa:u,2109:0715:u,152d:0578:u,152d:0579:u,152d:1561:u,174c:0829:u,14b0:0206:u,174c:225c:u,7825:a2a4:u,152d:0562:u,125f:a88a:u,152d:a583:u"
 
 # output where we are booting from
 itest.b ${devnum} == 0 && echo "U-boot loaded from SD"
 itest.b ${devnum} == 1 && echo "U-boot loaded from eMMC"
-
-# decide kernel image on rootfs
-if test -e ${devtype} ${devnum}:${rootfs} /Image; then
-  setenv kernel_img /Image
-  setenv kernel_bootcmd booti
-else
-  setenv kernel_img /zImage
-  setenv kernel_bootcmd bootz
-fi
 
 # import environment from /boot/bootEnv.txt
 if test -e ${devtype} ${devnum}:${bootfs} bootEnv.txt; then
@@ -32,9 +25,7 @@ fi
 # test if the gpio button is 0 (pressed) or if .recoveryMode exists in userfs
 # or if Image doesn't exist in the root partition
 gpio input ${gpio_button}
-if test $? -eq 0 \
-   -o -e ${devtype} ${devnum}:${userfs} /.recoveryMode \
-   -o ! -e ${devtype} ${devnum}:${rootfs} ${kernel_img}; then
+if test $? -eq 0 -o -e ${devtype} ${devnum}:${userfs} /.recoveryMode -o ! -e ${devtype} ${devnum}:${rootfs} ${kernel_img}; then
   echo "==== STARTING RECOVERY SYSTEM ===="
   # load the initrd file
   load ${devtype} ${devnum}:${bootfs} ${load_addr} ${recoveryfs_initrd}

--- a/buildroot-external/board/rpi4/boot.cmd
+++ b/buildroot-external/board/rpi4/boot.cmd
@@ -7,21 +7,14 @@ setenv bootfs 1
 setenv rootfs 2
 setenv userfs 3
 setenv gpio_button "GPIO12"
+setenv kernel_img /Image
+setenv kernel_bootcmd booti
 setenv recoveryfs_initrd "recoveryfs-initrd"
 setenv usbstoragequirks "174c:55aa:u,2109:0715:u,152d:0578:u,152d:0579:u,152d:1561:u,174c:0829:u,14b0:0206:u,174c:225c:u,7825:a2a4:u,152d:0562:u,125f:a88a:u,152d:a583:u"
 
 # output where we are booting from
 itest.b ${devnum} == 0 && echo "U-boot loaded from SD"
 itest.b ${devnum} == 1 && echo "U-boot loaded from eMMC"
-
-# decide kernel image on rootfs
-if test -e ${devtype} ${devnum}:${rootfs} /Image; then
-  setenv kernel_img /Image
-  setenv kernel_bootcmd booti
-else
-  setenv kernel_img /zImage
-  setenv kernel_bootcmd bootz
-fi
 
 # import environment from /boot/bootEnv.txt
 if test -e ${devtype} ${devnum}:${bootfs} bootEnv.txt; then
@@ -32,9 +25,7 @@ fi
 # test if the gpio button is 0 (pressed) or if .recoveryMode exists in userfs
 # or if Image doesn't exist in the root partition
 gpio input ${gpio_button}
-if test $? -eq 0 \
-   -o -e ${devtype} ${devnum}:${userfs} /.recoveryMode \
-   -o ! -e ${devtype} ${devnum}:${rootfs} ${kernel_img}; then
+if test $? -eq 0 -o -e ${devtype} ${devnum}:${userfs} /.recoveryMode -o ! -e ${devtype} ${devnum}:${rootfs} ${kernel_img}; then
   echo "==== STARTING RECOVERY SYSTEM ===="
   # load the initrd file
   load ${devtype} ${devnum}:${bootfs} ${load_addr} ${recoveryfs_initrd}

--- a/buildroot-external/board/rpi5/boot.cmd
+++ b/buildroot-external/board/rpi5/boot.cmd
@@ -7,6 +7,8 @@ setenv bootfs 1
 setenv rootfs 2
 setenv userfs 3
 setenv gpio_button "GPIO12"
+setenv kernel_img /Image
+setenv kernel_bootcmd booti
 setenv recoveryfs_initrd "recoveryfs-initrd"
 setenv usbstoragequirks "174c:55aa:u,2109:0715:u,152d:0578:u,152d:0579:u,152d:1561:u,174c:0829:u,14b0:0206:u,174c:225c:u,7825:a2a4:u,152d:0562:u,125f:a88a:u,152d:a583:u"
 
@@ -14,15 +16,6 @@ setenv usbstoragequirks "174c:55aa:u,2109:0715:u,152d:0578:u,152d:0579:u,152d:15
 itest.b ${devnum} == 0 && echo "U-boot loaded from SD"
 itest.b ${devnum} == 1 && echo "U-boot loaded from eMMC"
 
-# decide kernel image on rootfs
-if test -e ${devtype} ${devnum}:${rootfs} /Image; then
-  setenv kernel_img /Image
-  setenv kernel_bootcmd booti
-else
-  setenv kernel_img /zImage
-  setenv kernel_bootcmd bootz
-fi
- 
 # import environment from /boot/bootEnv.txt
 if test -e ${devtype} ${devnum}:${bootfs} bootEnv.txt; then
   load ${devtype} ${devnum}:${bootfs} ${load_addr} bootEnv.txt
@@ -32,9 +25,7 @@ fi
 # test if the gpio button is 0 (pressed) or if .recoveryMode exists in userfs
 # or if Image doesn't exist in the root partition
 gpio input ${gpio_button}
-if test $? -eq 0 \
-   -o -e ${devtype} ${devnum}:${userfs} /.recoveryMode \
-   -o ! -e ${devtype} ${devnum}:${rootfs} ${kernel_img}; then
+if test $? -eq 0 -o -e ${devtype} ${devnum}:${userfs} /.recoveryMode -o ! -e ${devtype} ${devnum}:${rootfs} ${kernel_img}; then
   echo "==== STARTING RECOVERY SYSTEM ===="
   # load the initrd file
   load ${devtype} ${devnum}:${bootfs} ${load_addr} ${recoveryfs_initrd}

--- a/buildroot-external/board/tinkerboard/boot.cmd
+++ b/buildroot-external/board/tinkerboard/boot.cmd
@@ -7,20 +7,13 @@ setenv bootfs 1
 setenv rootfs 2
 setenv userfs 3
 setenv gpio_button "H23" # matches GPIO239
+setenv kernel_img /zImage
+setenv kernel_bootcmd bootz
 setenv recoveryfs_initrd "recoveryfs-initrd"
 setenv overlays ""
 setenv usbstoragequirks "0x2537:0x1066:u,0x2537:0x1068:u"
 
 echo "Boot script loaded from ${devtype} ${devnum}"
-
-# decide kernel image on rootfs
-if test -e ${devtype} ${devnum}:${rootfs} /zImage; then
-  setenv kernel_img /zImage
-  setenv kernel_bootcmd bootz
-else
-  setenv kernel_img /Image
-  setenv kernel_bootcmd booti
-fi
 
 # import environment from /boot/bootEnv.txt
 if test -e ${devtype} ${devnum}:${bootfs} bootEnv.txt; then
@@ -31,9 +24,7 @@ fi
 # test if the gpio button is 0 (pressed) or if .recoveryMode exists in userfs
 # or if zImage doesn't exist in the root partition
 gpio input ${gpio_button}
-if test $? -eq 0 \
-   -o -e ${devtype} ${devnum}:${userfs} /.recoveryMode \
-   -o ! -e ${devtype} ${devnum}:${rootfs} ${kernel_img}; then
+if test $? -eq 0 -o -e ${devtype} ${devnum}:${userfs} /.recoveryMode -o ! -e ${devtype} ${devnum}:${rootfs} ${kernel_img}; then
   echo "==== STARTING RECOVERY SYSTEM ===="
   # load the initrd file
   load ${devtype} ${devnum}:${bootfs} ${ramdisk_addr_r} ${recoveryfs_initrd}


### PR DESCRIPTION
This change fixes the boot script of all U-Boot supported platforms and reverts the Image vs. zImage check and fixes the gpio button test line to be a single line test as the uboot script obviously does not support multi-line if statements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Standardized boot configuration via kernel_img and kernel_bootcmd across Odroid C4/N2, Raspberry Pi (0/2/3/4/5), and Tinkerboard.
  - Environment variables from bootEnv.txt are now imported at boot.
- Bug Fixes
  - More reliable recovery activation when the kernel image is missing or recovery mode is requested.
- Refactor
  - Simplified and unified recovery checks into a single condition.
  - Removed conditional kernel image/boot command selection for faster, more predictable boots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->