### PR TITLE
revert snok/container-retention-policy action to v3.0.0

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -589,7 +589,7 @@ jobs:
         continue-on-error: true
 
       - name: Remove old unused container images
-        uses: snok/container-retention-policy@v3.0.1
+        uses: snok/container-retention-policy@v3.0.0
         with:
           account: user
           token: ${{ secrets.CR_PAT }}


### PR DESCRIPTION
This change downgrades the snok/container-retention-policy action to version 3.0.0 since v3.0.1 seems to be broken and causes workflow errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated the CI workflow responsible for cleaning up old container images, switching to a different action version to improve reliability of the cleanup process.
  - Ensures continued, predictable pruning of outdated images in snapshot builds.
  - No changes to application functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->