### PR TITLE
Revert "Bump snok/container-retention-policy from 3.0.0 to 3.0.1

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -589,7 +589,7 @@ jobs:
         continue-on-error: true
 
       - name: Remove old unused container images
-        uses: snok/container-retention-policy@v3.0.1
+        uses: snok/container-retention-policy@v3.0.0
         with:
           account: user
           token: ${{ secrets.CR_PAT }}


### PR DESCRIPTION
This reverts commit 129f167388c135e5ad5bf1974e7d274f885dce46.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI automation for cleaning up unused container images by adjusting the workflow action version to ensure consistent pipeline behavior.
  * No changes to application features, interface, or performance.
  * Improves build reliability and operational hygiene.
  * No action required from end-users; the application continues to function as before.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->