### PR TITLE
rpi-rf-mod-yellow.dts: remove unconnected pins clashing with onboard I2S

### DIFF
--- a/buildroot-external/package/rpi-rf-mod/dts/rpi-rf-mod-yellow.dts
+++ b/buildroot-external/package/rpi-rf-mod/dts/rpi-rf-mod-yellow.dts
@@ -13,32 +13,9 @@
 / {
     compatible = "brcm,bcm2708";
 
-    // fragment to ensure we have the correct gpio pin
-    // setup for the HM-MOD-RPI-PCB
-    fragment@0 {
-        target = <&gpio>;
-        __overlay__ {
-            rpi_rf_mod_pins: rpi_rf_mod_pins {
-                brcm,pins = <18>;    // 18=reset (HM-MOD-RPI-PCB)
-                brcm,pull = <0>;     // 18=no-pullup
-                brcm,function = <0>; // 18=input
-            };
-        };
-    };
-
-    // fragment to define dedicated led nodes for
-    // each separate led supported by the RPI-RF-MOD
-    fragment@1 {
-        target = <&leds>;
-        __overlay__ {
-            pinctrl-names = "default";
-            pinctrl-0 = <&rpi_rf_mod_pins>;
-        };
-    };
-
     // fragment to define uart/serial dependencies for
     // generic_raw_uart
-    fragment@2 {
+    fragment@0 {
         target = <&uart0>;
         __overlay__ {
             compatible = "pivccu,pl011";
@@ -50,7 +27,7 @@
     // fragment to make sure that stdout-path under chosen
     // is empty so that the above uart0 fragment does not
     // interfere with u-boot trying to access serial drivers.
-    fragment@3 {
+    fragment@1 {
         target = <&chosen>;
         __overlay__ {
             stdout-path = "";


### PR DESCRIPTION
Home Assitant Yellow only has 10-pin header for extensions, and gpio18 is already used for onboard I2S audio. Remove fragments configuring the LEDs which can otherwise break the onboard audio.

Without this change enabling rpi-rf-mod on HA Yellow causes:

[    6.478090] pinctrl-bcm2835 fe200000.gpio: pin gpio18 already requested by leds; cannot claim for fe203000.i2s
[    6.571824] pinctrl-bcm2835 fe200000.gpio: error -EINVAL: pin-18 (fe203000.i2s)
[    6.634031] pinctrl-bcm2835 fe200000.gpio: error -EINVAL: could not request pin 18 (gpio18) from group gpio18 on device pinctrl-bcm2711
[    6.647392] bcm2835-i2s fe203000.i2s: Error applying setting, reverse things back

Fixes #3251