### PR TITLE
use hadolint/hadolint-action@v3.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Check Dockerfile
-        uses: brpaz/hadolint-action@v1.5.0
+        uses: hadolint/hadolint-action@v3.3.0
         with:
           dockerfile: ./buildroot-external/board/oci/Dockerfile
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CI pipeline’s Dockerfile linting step to use a newer, actively maintained action.
  * Improves reliability, security posture, and consistency of linting across builds.
  * No impact on application behavior or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->