### PR TITLE
add termios2 compatibility to eq3_char_loop

### DIFF
--- a/buildroot-external/package/eq3_char_loop/0005-eq3_char_loop-termios2.patch
+++ b/buildroot-external/package/eq3_char_loop/0005-eq3_char_loop-termios2.patch
@@ -1,0 +1,120 @@
+Upstream: Not applicable
+
+Signed-off-by: Jens Maus <mail@jens-maus.de>
+
+--- a/KernelDrivers/eq3_char_loop.c
++++ b/KernelDrivers/eq3_char_loop.c
+@@ -40,6 +40,7 @@
+ #include <asm/termbits.h>
+ #include <asm/termios.h>
+ #include <asm/ioctls.h>
++#include <linux/serial.h>
+ #include <linux/version.h>
+ 
+ #define EQ3LOOP_NUMBER_OF_CHANNELS 4
+@@ -514,6 +515,8 @@
+ 		}
+ 		break;
+ 	case TCSETS:
++	case TCSETSW:
++	case TCSETSF:
+ 		if( _access_ok(VERIFY_WRITE, (void *)arg, sizeof(struct termios) ) )
+ 		{
+ 			ret = copy_from_user( &channel->termios, (void*)arg, sizeof(struct termios) );
+@@ -521,6 +524,59 @@
+ 			ret = -EFAULT;
+ 		}
+ 		break;
++#ifdef TCGETS2
++	case TCGETS2:
++	{
++		struct termios2 t2;
++	
++		memset(&t2, 0, sizeof(t2));
++		t2.c_iflag = channel->termios.c_iflag;
++		t2.c_oflag = channel->termios.c_oflag;
++		t2.c_cflag = channel->termios.c_cflag;
++		t2.c_lflag = channel->termios.c_lflag;
++		t2.c_line  = channel->termios.c_line;
++		memcpy(t2.c_cc, channel->termios.c_cc, NCCS);
++		t2.c_ispeed = 0;
++		t2.c_ospeed = 0;
++	
++		if( _access_ok(VERIFY_READ, (void *)arg, sizeof(struct termios2) ) )
++		{
++			ret = copy_to_user( (void*)arg, &t2, sizeof(struct termios2) );
++		} else {
++			ret = -EFAULT;
++		}
++		break;
++	}
++#endif
++#ifdef TCSETS2
++	case TCSETS2:
++#ifdef TCSETSW2
++	case TCSETSW2:
++#endif
++#ifdef TCSETSF2
++	case TCSETSF2:
++#endif
++	{
++		struct termios2 t2;
++	
++		if( _access_ok(VERIFY_WRITE, (void *)arg, sizeof(struct termios2) ) )
++		{
++			ret = copy_from_user( &t2, (void*)arg, sizeof(struct termios2) );
++			if( !ret )
++			{
++				channel->termios.c_iflag = t2.c_iflag;
++				channel->termios.c_oflag = t2.c_oflag;
++				channel->termios.c_cflag = t2.c_cflag;
++				channel->termios.c_lflag = t2.c_lflag;
++				channel->termios.c_line  = t2.c_line;
++				memcpy(channel->termios.c_cc, t2.c_cc, NCCS);
++			}
++		} else {
++			ret = -EFAULT;
++		}
++		break;
++	}
++#endif
+ 	case TIOCINQ:
+ 		temp = CIRC_CNT( channel->master2slave_buf.head, channel->master2slave_buf.tail, BUFSIZE);
+ 		ret = __put_user( temp, (int*)arg );
+@@ -540,10 +596,20 @@
+ 	case TIOCMSET:
+ 		break;
+ 	case TIOCSERGETLSR:
+-		ret = -ENOIOCTLCMD;
++		temp = TIOCSER_TEMT;
++		ret = __put_user( temp, (int*)arg );
+ 		break;
+ 	case TIOCGICOUNT:
+-		ret = -ENOIOCTLCMD;
++		{
++			struct serial_icounter_struct icount;
++			memset(&icount, 0, sizeof(icount));
++			if( _access_ok(VERIFY_READ, (void *)arg, sizeof(struct serial_icounter_struct) ) )
++			{
++				ret = copy_to_user( (void*)arg, &icount, sizeof(struct serial_icounter_struct) );
++			} else {
++				ret = -EFAULT;
++			}
++		}
+ 		break;
+ 	default:
+ 		ret = -ENOTTY;
+@@ -553,7 +619,6 @@
+ 	if( ret == -ENOTTY )
+ 	{
+ 		printk( KERN_NOTICE EQ3LOOP_DRIVER_NAME ": eq3loop_ioctl_slave() %s: unhandled ioctl 0x%04X\n", channel->name, cmd );
+-		ret = -ENOIOCTLCMD;
+ 	}
+ 	return ret;
+ }
+@@ -1004,4 +1069,4 @@
+ module_exit(eq3loop_exit);
+ MODULE_DESCRIPTION("eQ-3 IPC loopback char driver");
+ MODULE_LICENSE("GPL");
+-MODULE_VERSION("1.2");
++MODULE_VERSION("1.3");

--- a/buildroot-external/package/eq3_char_loop/0005-eq3_char_loop-termios2.patch
+++ b/buildroot-external/package/eq3_char_loop/0005-eq3_char_loop-termios2.patch
@@ -12,16 +12,26 @@ Signed-off-by: Jens Maus <mail@jens-maus.de>
  #include <linux/version.h>
  
  #define EQ3LOOP_NUMBER_OF_CHANNELS 4
-@@ -514,6 +515,8 @@
+@@ -506,7 +507,7 @@
+ 	switch(cmd) {
+ 
+ 	case TCGETS:
+-		if( _access_ok(VERIFY_READ, (void *)arg, sizeof(struct termios) ) )
++		if( _access_ok(VERIFY_WRITE, (void *)arg, sizeof(struct termios) ) )
+ 		{
+ 			ret = copy_to_user( (void*)arg, &channel->termios, sizeof(struct termios) );
+ 		} else {
+@@ -514,13 +515,68 @@
  		}
  		break;
  	case TCSETS:
+-		if( _access_ok(VERIFY_WRITE, (void *)arg, sizeof(struct termios) ) )
 +	case TCSETSW:
 +	case TCSETSF:
- 		if( _access_ok(VERIFY_WRITE, (void *)arg, sizeof(struct termios) ) )
++		if( _access_ok(VERIFY_READ, (void *)arg, sizeof(struct termios) ) )
  		{
  			ret = copy_from_user( &channel->termios, (void*)arg, sizeof(struct termios) );
-@@ -521,6 +524,59 @@
+ 		} else {
  			ret = -EFAULT;
  		}
  		break;
@@ -40,7 +50,7 @@ Signed-off-by: Jens Maus <mail@jens-maus.de>
 +		t2.c_ispeed = 0;
 +		t2.c_ospeed = 0;
 +	
-+		if( _access_ok(VERIFY_READ, (void *)arg, sizeof(struct termios2) ) )
++		if( _access_ok(VERIFY_WRITE, (void *)arg, sizeof(struct termios2) ) )
 +		{
 +			ret = copy_to_user( (void*)arg, &t2, sizeof(struct termios2) );
 +		} else {
@@ -60,7 +70,7 @@ Signed-off-by: Jens Maus <mail@jens-maus.de>
 +	{
 +		struct termios2 t2;
 +	
-+		if( _access_ok(VERIFY_WRITE, (void *)arg, sizeof(struct termios2) ) )
++		if( _access_ok(VERIFY_READ, (void *)arg, sizeof(struct termios2) ) )
 +		{
 +			ret = copy_from_user( &t2, (void*)arg, sizeof(struct termios2) );
 +			if( !ret )
@@ -94,7 +104,7 @@ Signed-off-by: Jens Maus <mail@jens-maus.de>
 +		{
 +			struct serial_icounter_struct icount;
 +			memset(&icount, 0, sizeof(icount));
-+			if( _access_ok(VERIFY_READ, (void *)arg, sizeof(struct serial_icounter_struct) ) )
++			if( _access_ok(VERIFY_WRITE, (void *)arg, sizeof(struct serial_icounter_struct) ) )
 +			{
 +				ret = copy_to_user( (void*)arg, &icount, sizeof(struct serial_icounter_struct) );
 +			} else {


### PR DESCRIPTION
This PR adds termios2 (TCGETS2/TCSETS2, etc.) ioctl catches to eq3_char_loop kernel driver to get it compatible with glibc 2.42+ which seem to use termios2 ioctl now. In addition, the TIOCSERGETLSR and TIOCGICOUNT ioctl won't return -ENOIOCTLCMD anymore but use valid stubs for correctly answer these ioctl. And -ENOTTY will now be returned for any unknown ioctl making applications react more correctly.

Alltogether this should fix issues with buildroot 2025.11 using glibc 2.42 and a non-working HMIPServer using eq3_char_loop devices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended terminal control and serial-device operations for broader device compatibility and advanced control modes.
  * Improved device status reporting and diagnostics for clearer runtime visibility.

* **Bug Fixes**
  * Strengthened memory-access validation and safer handling of terminal control requests to reduce errors.
  * More robust fallback behavior and consistent error reporting for unhandled operations.

* **Updates**
  * Module version upgraded to 1.3.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->