### PR TITLE
fix partly broken monitrc due to dbus startup rename

### DIFF
--- a/buildroot-external/overlay/base-openccu/etc/monitrc
+++ b/buildroot-external/overlay/base-openccu/etc/monitrc
@@ -90,9 +90,9 @@ check program irqbalanceEnabled with path /bin/sh -c "/usr/bin/test $(nproc) -gt
 # dbus daemon monitoring
 check process dbus with pidfile /run/messagebus.pid
     group system
-    start = "/etc/init.d/S30dbus start"
-    stop = "/etc/init.d/S30dbus stop"
-    restart = "/etc/init.d/S30dbus restart"
+    start = "/etc/init.d/S30dbus-daemon start"
+    stop = "/etc/init.d/S30dbus-daemon stop"
+    restart = "/etc/init.d/S30dbus-daemon restart"
     if not exist for 1 cycles then restart
     if failed unixsocket /run/dbus/system_bus_socket for 5 cycles then restart
     if 1 restart within 1 cycles then

--- a/buildroot-external/patches/occu/0001-OpenCCU.patch
+++ b/buildroot-external/patches/occu/0001-OpenCCU.patch
@@ -359,12 +359,12 @@
 +      set STATUS "${label}(0) $STATUS"
 +    }
 +  }
-+  execCmd ROOTFSFREE {exec monit status rootfs | grep -m1 "space free for non superuser" | awk {{ print substr($0,index($0,$6)) }}}
-+  execCmd ROOTFSTOTAL {exec monit status rootfs | grep -m1 "space total" | awk {{ print $3 " " $4 }}}
-+  execCmd USERFSFREE {exec monit status userfs | grep -m1 "space free for non superuser" | awk {{ print substr($0,index($0,$6)) }}}
-+  execCmd USERFSTOTAL {exec monit status userfs | grep -m1 "space total" | awk {{ print $3 " " $4 }}}
-+  execCmd USBDEVFREE {exec monit status usb1 | grep -m1 "space free for non superuser" | awk {{ print substr($0,index($0,$6)) }}}
-+  execCmd USBDEVTOTAL {exec monit status usb1 | grep -m1 "space total" | awk {{ print $3 " " $4 }}}
++  execCmd ROOTFSFREE {exec monit status rootfs 2>/dev/null | grep -m1 "space free for non superuser" | awk {{ print substr($0,index($0,$6)) }}}
++  execCmd ROOTFSTOTAL {exec monit status rootfs 2>/dev/null | grep -m1 "space total" | awk {{ print $3 " " $4 }}}
++  execCmd USERFSFREE {exec monit status userfs 2>/dev/null | grep -m1 "space free for non superuser" | awk {{ print substr($0,index($0,$6)) }}}
++  execCmd USERFSTOTAL {exec monit status userfs 2>/dev/null | grep -m1 "space total" | awk {{ print $3 " " $4 }}}
++  execCmd USBDEVFREE {exec monit status usb1 2>/dev/null | grep -m1 "space free for non superuser" | awk {{ print substr($0,index($0,$6)) }}}
++  execCmd USBDEVTOTAL {exec monit status usb1 2>/dev/null | grep -m1 "space total" | awk {{ print $3 " " $4 }}}
 +  execCmd STORAGEDEV {exec mountpoint -n /usr/local | awk {{ print $1 }} | xargs lsblk -l -n -o PKNAME -p}
 +  execCmd STORAGE "exec lsblk -l -n -o SIZE,MODEL,KNAME -d -p $STORAGEDEV"
 +  set HMRF_DUTYCYCLE "n/a"

--- a/buildroot-external/patches/occu/0001-OpenCCU/occu/WebUI/www/config/help.cgi
+++ b/buildroot-external/patches/occu/0001-OpenCCU/occu/WebUI/www/config/help.cgi
@@ -144,12 +144,12 @@ proc action_put_page {} {
       set STATUS "${label}(0) $STATUS"
     }
   }
-  execCmd ROOTFSFREE {exec monit status rootfs | grep -m1 "space free for non superuser" | awk {{ print substr($0,index($0,$6)) }}}
-  execCmd ROOTFSTOTAL {exec monit status rootfs | grep -m1 "space total" | awk {{ print $3 " " $4 }}}
-  execCmd USERFSFREE {exec monit status userfs | grep -m1 "space free for non superuser" | awk {{ print substr($0,index($0,$6)) }}}
-  execCmd USERFSTOTAL {exec monit status userfs | grep -m1 "space total" | awk {{ print $3 " " $4 }}}
-  execCmd USBDEVFREE {exec monit status usb1 | grep -m1 "space free for non superuser" | awk {{ print substr($0,index($0,$6)) }}}
-  execCmd USBDEVTOTAL {exec monit status usb1 | grep -m1 "space total" | awk {{ print $3 " " $4 }}}
+  execCmd ROOTFSFREE {exec monit status rootfs 2>/dev/null | grep -m1 "space free for non superuser" | awk {{ print substr($0,index($0,$6)) }}}
+  execCmd ROOTFSTOTAL {exec monit status rootfs 2>/dev/null | grep -m1 "space total" | awk {{ print $3 " " $4 }}}
+  execCmd USERFSFREE {exec monit status userfs 2>/dev/null | grep -m1 "space free for non superuser" | awk {{ print substr($0,index($0,$6)) }}}
+  execCmd USERFSTOTAL {exec monit status userfs 2>/dev/null | grep -m1 "space total" | awk {{ print $3 " " $4 }}}
+  execCmd USBDEVFREE {exec monit status usb1 2>/dev/null | grep -m1 "space free for non superuser" | awk {{ print substr($0,index($0,$6)) }}}
+  execCmd USBDEVTOTAL {exec monit status usb1 2>/dev/null | grep -m1 "space total" | awk {{ print $3 " " $4 }}}
   execCmd STORAGEDEV {exec mountpoint -n /usr/local | awk {{ print $1 }} | xargs lsblk -l -n -o PKNAME -p}
   execCmd STORAGE "exec lsblk -l -n -o SIZE,MODEL,KNAME -d -p $STORAGEDEV"
   set HMRF_DUTYCYCLE "n/a"


### PR DESCRIPTION
This fixes issue #3485 which is a result of the buildroot 2025.11.1
upgrade which includes a change in the dbus daemon startup script
which was renamed from S30dbus to S30dbus-daemon.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added enriched system information display, including hardware, software, storage, and network details.

* **Bug Fixes**
  * Improved error handling in system monitoring status checks.

* **Updates**
  * Rebranded user interface with OpenCCU assets and terminology.
  * Enhanced version and platform detection for dynamic update flows.
  * Improved URL and IP address handling for better cross-environment compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->