### PR TITLE
retire 32bit architectures for HA proxy addon

### DIFF
--- a/home-assistant-addon-proxy/Dockerfile
+++ b/home-assistant-addon-proxy/Dockerfile
@@ -25,7 +25,7 @@ LABEL \
     io.hass.name="OpenCCU (Proxy)" \
     io.hass.description="Proxy to externally running OpenCCU" \
     io.hass.url=https://github.com/OpenCCU/OpenCCU/tree/master/home-assistant-addon-proxy \
-    io.hass.arch="armv7|aarch64|amd64" \
+    io.hass.arch="aarch64|amd64" \
     io.hass.type="addon" \
     io.hass.version=${package_version}
 

--- a/home-assistant-addon-proxy/README.md
+++ b/home-assistant-addon-proxy/README.md
@@ -1,6 +1,6 @@
 # Home Assistant App: OpenCCU Proxy
 
-![Supports aarch64 Architecture][aarch64-shield] ![Supports amd64 Architecture][amd64-shield] ![Supports armhf Architecture][armhf-shield] ![Supports armv7 Architecture][armv7-shield] ![Supports i386 Architecture][i386-shield]
+![Supports aarch64 Architecture][aarch64-shield] ![Supports amd64 Architecture][amd64-shield]
 [![License](https://img.shields.io/github/license/OpenCCU/OpenCCU.svg)](https://github.com/OpenCCU/OpenCCU/blob/master/LICENSE)
 [![Donate](https://img.shields.io/badge/donate-PayPal-green.svg)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=RAQSDY9YNZVCL)
 [![GitHub stars](https://img.shields.io/github/stars/OpenCCU/OpenCCU.svg?style=social&label=Star)](https://github.com/OpenCCU/OpenCCU/stargazers/)
@@ -25,7 +25,4 @@ This Home Assistant App as well as OpenCCU is licensed under the Apache-2.0 open
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
-[armhf-shield]: https://img.shields.io/badge/armhf-no-red.svg
-[armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
-[i386-shield]: https://img.shields.io/badge/i386-no-red.svg
 [openccu]: https://github.com/OpenCCU/OpenCCU

--- a/home-assistant-addon-proxy/config.yaml
+++ b/home-assistant-addon-proxy/config.yaml
@@ -1,10 +1,9 @@
 ---
 name: OpenCCU (Proxy)
-version: 0.4.3
+version: 0.5.0
 slug: openccu_proxy
 image: ghcr.io/openccu/openccu-proxy
 arch:
-  - armv7
   - aarch64
   - amd64
 description: Proxy to externally running OpenCCU


### PR DESCRIPTION
This change retires all 32bit architectures (including armv7) for the HA proxy addon/app since newer HA versions anyway just allow 64bit platforms anymore and otherwise trigger a deprecation warning. This fixes #3726.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.5.0
  * Removed armv7 architecture support; addon now supports aarch64 and amd64 platforms only
  * Updated documentation and configurations to reflect current architecture compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->