### PR TITLE
switch rpi to use vc4-kms-v3d/DRM framebuffer

### DIFF
--- a/buildroot-external/board/rpi3/config.txt
+++ b/buildroot-external/board/rpi3/config.txt
@@ -18,6 +18,10 @@ disable_overscan=1
 # Added to fix #3046
 initial_turbo=0
 
+# Enable DRM VC4 V3D driver
+dtoverlay=vc4-kms-v3d
+max_framebuffers=1
+
 # enable i2c and spi
 dtparam=i2c_arm=on
 dtparam=i2c1=on

--- a/buildroot-external/board/rpi3/kernel.config
+++ b/buildroot-external/board/rpi3/kernel.config
@@ -1,3 +1,18 @@
+# enable DRM/HDMI
+CONFIG_DRM=y
+CONFIG_DRM_KMS_HELPER=y
+CONFIG_DRM_GEM_DMA_HELPER=y
+CONFIG_DRM_DISPLAY_HELPER=y
+CONFIG_DRM_DISPLAY_HDMI_HELPER=y
+CONFIG_DRM_DISPLAY_HDMI_STATE_HELPER=y
+CONFIG_DRM_VC4=y
+CONFIG_HDMI=y
+
+# enable basic sound config (required for vc4)
+CONFIG_SOUND=y
+CONFIG_SND=y
+CONFIG_SND_SOC=y
+
 # disable old framebuffer for video display to work
 # CONFIG_FB_BCM2708 is not set
 

--- a/buildroot-external/board/rpi4/config.txt
+++ b/buildroot-external/board/rpi4/config.txt
@@ -19,6 +19,10 @@ gpu_mem=32
 # If the text shown on the screen disappears off the edge, comment this out
 disable_overscan=1
 
+# Enable DRM VC4 V3D driver
+dtoverlay=vc4-kms-v3d
+max_framebuffers=1
+
 # enable i2c and spi
 dtparam=i2c_arm=on
 dtparam=i2c1=on

--- a/buildroot-external/board/rpi4/kernel.config
+++ b/buildroot-external/board/rpi4/kernel.config
@@ -1,3 +1,18 @@
+# enable DRM/HDMI
+CONFIG_DRM=y
+CONFIG_DRM_KMS_HELPER=y
+CONFIG_DRM_GEM_DMA_HELPER=y
+CONFIG_DRM_DISPLAY_HELPER=y
+CONFIG_DRM_DISPLAY_HDMI_HELPER=y
+CONFIG_DRM_DISPLAY_HDMI_STATE_HELPER=y
+CONFIG_DRM_VC4=y
+CONFIG_HDMI=y
+
+# enable basic sound config (required for vc4)
+CONFIG_SOUND=y
+CONFIG_SND=y
+CONFIG_SND_SOC=y
+
 # disable old framebuffer for video display to work
 # CONFIG_FB_BCM2708 is not set
 

--- a/buildroot-external/board/rpi5/kernel.config
+++ b/buildroot-external/board/rpi5/kernel.config
@@ -1,3 +1,18 @@
+# enable DRM/HDMI
+CONFIG_DRM=y
+CONFIG_DRM_KMS_HELPER=y
+CONFIG_DRM_GEM_DMA_HELPER=y
+CONFIG_DRM_DISPLAY_HELPER=y
+CONFIG_DRM_DISPLAY_HDMI_HELPER=y
+CONFIG_DRM_DISPLAY_HDMI_STATE_HELPER=y
+CONFIG_DRM_VC4=y
+CONFIG_HDMI=y
+
+# enable basic sound config (required for vc4)
+CONFIG_SOUND=y
+CONFIG_SND=y
+CONFIG_SND_SOC=y
+
 # disable old framebuffer for video display to work
 # CONFIG_FB_BCM2708 is not set
 


### PR DESCRIPTION
This enables the vc4-kms-v3d dtoverlay for all rpi platforms and enables DRM as well. This should resolve issues with potentially crashing 6.18 kernels due to use of the old obsolete vchiq interfaces which do not work reliable anymore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Configured DRM VC4 graphics driver and display support for Raspberry Pi 3, 4, and 5.
  * Optimized display framebuffer settings for enhanced stability.
  * Enabled HDMI and audio support across all supported Pi models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->