### PR TITLE
add missing libs for vcgencmd

### DIFF
--- a/buildroot-external/package/vcgencmd/vcgencmd.mk
+++ b/buildroot-external/package/vcgencmd/vcgencmd.mk
@@ -22,6 +22,9 @@ VCGENCMD_CONF_OPTS = \
 
 define VCGENCMD_INSTALL_TARGET_CMDS
 	$(INSTALL) -D -m 0755 $(STAGING_DIR)/usr/bin/vcgencmd $(TARGET_DIR)/usr/bin/vcgencmd
+	$(INSTALL) -D -m 0755 $(STAGING_DIR)/usr/lib/libvchostif.so $(TARGET_DIR)/usr/lib/libvchostif.so
+	$(INSTALL) -D -m 0755 $(STAGING_DIR)/usr/lib/libvchiq_arm.so $(TARGET_DIR)/usr/lib/libvchiq_arm.so
+	$(INSTALL) -D -m 0755 $(STAGING_DIR)/usr/lib/libvcos.so $(TARGET_DIR)/usr/lib/libvcos.so
 endef
 
 $(eval $(cmake-package))

--- a/buildroot-external/package/vcgencmd/vcgencmd.mk
+++ b/buildroot-external/package/vcgencmd/vcgencmd.mk
@@ -22,9 +22,9 @@ VCGENCMD_CONF_OPTS = \
 
 define VCGENCMD_INSTALL_TARGET_CMDS
 	$(INSTALL) -D -m 0755 $(STAGING_DIR)/usr/bin/vcgencmd $(TARGET_DIR)/usr/bin/vcgencmd
-	$(INSTALL) -D -m 0755 $(STAGING_DIR)/usr/lib/libvchostif.so $(TARGET_DIR)/usr/lib/libvchostif.so
-	$(INSTALL) -D -m 0755 $(STAGING_DIR)/usr/lib/libvchiq_arm.so $(TARGET_DIR)/usr/lib/libvchiq_arm.so
-	$(INSTALL) -D -m 0755 $(STAGING_DIR)/usr/lib/libvcos.so $(TARGET_DIR)/usr/lib/libvcos.so
+	$(INSTALL) -D -m 0644 $(STAGING_DIR)/usr/lib/libvchostif.so $(TARGET_DIR)/usr/lib/libvchostif.so
+	$(INSTALL) -D -m 0644 $(STAGING_DIR)/usr/lib/libvchiq_arm.so $(TARGET_DIR)/usr/lib/libvchiq_arm.so
+	$(INSTALL) -D -m 0644 $(STAGING_DIR)/usr/lib/libvcos.so $(TARGET_DIR)/usr/lib/libvcos.so
 endef
 
 $(eval $(cmake-package))


### PR DESCRIPTION
This adds the necessary install statements for vcgencmd to be correctly executable due to previously missing shared libraries from the rpi-userland ecosystem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted installation configuration to include additional shared libraries in the target filesystem, ensuring required runtime libraries are deployed alongside the existing executable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->