### PR TITLE
add modprobe -r to unload brcmfmac on rpi platform

### DIFF
--- a/buildroot-external/overlay/base/etc/network/if-up.d/eQ3StartNetwork
+++ b/buildroot-external/overlay/base/etc/network/if-up.d/eQ3StartNetwork
@@ -47,6 +47,10 @@ if [[ -f /var/status/hasIP ]] &&
     wlan*)
       /usr/sbin/iw dev "${IFACE}" set power_save on
       /usr/sbin/rfkill block wlan
+      if echo "${HM_HOST}" | grep -q rpi; then
+        modprobe -r brcmfmac_wcc brcmfmac_cyw brcmfmac brcmutil 2>/dev/null
+        echo -n "poweroff, "
+      fi
     ;;
   esac
   exit 0
@@ -129,6 +133,10 @@ case "${IFACE}" in
       # if not required
       /usr/sbin/iw dev "${IFACE}" set power_save on
       /usr/sbin/rfkill block wlan
+      if echo "${HM_HOST}" | grep -q rpi; then
+        modprobe -r brcmfmac_wcc brcmfmac_cyw brcmfmac brcmutil 2>/dev/null
+        echo -n "disable+poweroff, "
+      fi
       exit 1
     fi
   ;;


### PR DESCRIPTION
This adds a final kernel module unload step after the "rfkill block wlan" steps to unload the brcmfmac kernel driver to ensure all WiFi related kernel modules are unloaded and thus force a system into WiFi poweroff mode. This might help to further reduce any RF interferences on the various RaspberryPi platforms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WiFi module handling on Raspberry Pi devices to ensure proper network interface initialization and shutdown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->