### PR TITLE
rework the RaspberryPi under-voltage monit check

### DIFF
--- a/buildroot-external/overlay/base-openccu/bin/checkUndervoltage.sh
+++ b/buildroot-external/overlay/base-openccu/bin/checkUndervoltage.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+# checkUndervoltage.sh - platform independent undervoltage-check
+#
+# Exit codes:
+#   0 = no alarm active
+#   1 = no hwmon alarm files present (nothing to check)
+#   2 = at least one alarm is active
+
+# Check whether any *_alarm file exists before iterating.
+# Glob expands to itself if nothing matches, so a -e test is reliable.
+FOUND=0
+for f in /sys/class/hwmon/hwmon*/*_alarm; do
+    [ -e "$f" ] && FOUND=1 && break
+done
+
+if [ "$FOUND" -eq 0 ]; then
+    echo "No hwmon alarm files found" >&2
+    exit 1
+fi
+
+# iterate over all hwmon alarm stuff
+for f in /sys/class/hwmon/hwmon*/*_alarm; do
+    [ -r "$f" ] || continue
+    if [ "$(cat "$f" 2>/dev/null)" = "1" ]; then
+        echo "ALARM: $f"
+        exit 2
+    fi
+done
+
+echo "No undervoltage identified"
+
+exit 0

--- a/buildroot-external/overlay/base-openccu/bin/checkUndervoltage.sh
+++ b/buildroot-external/overlay/base-openccu/bin/checkUndervoltage.sh
@@ -6,10 +6,10 @@
 #   1 = no hwmon alarm files present (nothing to check)
 #   2 = at least one alarm is active
 
-# Check whether any *_alarm file exists before iterating.
+# Check whether any undervoltage-related alarm file exists before iterating.
 # Glob expands to itself if nothing matches, so a -e test is reliable.
 FOUND=0
-for f in /sys/class/hwmon/hwmon*/*_alarm; do
+for f in /sys/class/hwmon/hwmon*/in*_lcrit_alarm /sys/class/hwmon/hwmon*/in*_min_alarm; do
     [ -e "$f" ] && FOUND=1 && break
 done
 
@@ -18,8 +18,8 @@ if [ "$FOUND" -eq 0 ]; then
     exit 1
 fi
 
-# iterate over all hwmon alarm stuff
-for f in /sys/class/hwmon/hwmon*/*_alarm; do
+# iterate over undervoltage-related hwmon alarms
+for f in /sys/class/hwmon/hwmon*/in*_lcrit_alarm /sys/class/hwmon/hwmon*/in*_min_alarm; do
     [ -r "$f" ] || continue
     if [ "$(cat "$f" 2>/dev/null)" = "1" ]; then
         echo "ALARM: $f"

--- a/buildroot-external/overlay/base-openccu/etc/monitrc
+++ b/buildroot-external/overlay/base-openccu/etc/monitrc
@@ -416,17 +416,13 @@ check program wlan0CheckEnabled with path /bin/sh -c "[[ -e /etc/config/wpa_supp
     if status != 0 for 1 cycles then unmonitor
     depends on wlan0Exists
 
-# monitor under-voltage using vcgencmd (RaspberryPi only)
-check program voltageCheck with path /bin/sh -c "[ $(( $(/usr/bin/vcgencmd get_throttled | cut -f2 -d=) & 0x1 )) -eq $(( 0x1 )) ]"
+# monitor under-voltage condition (RaspberryPi only)
+check program underVoltageCheck with path "/bin/checkUndervoltage.sh"
     group system
-    if status = 0 for 2 cycles then
+    if status = 1 for 3 cycles then unmonitor
+    if status = 2 for 2 cycles then
       exec "/bin/triggerAlarm.tcl 'under-voltage detected' 'WatchDog: low-voltage' true"
       repeat every 24 cycles
-    depends on voltageCheckEnabled
-
-check program voltageCheckEnabled with path "/usr/bin/test -e /usr/bin/vcgencmd"
-    group system
-    if status != 0 for 1 cycles then unmonitor
 
 # internet connectivity monitoring
 check program internetCheck with path "/usr/bin/test -e /var/status/hasInternet"


### PR DESCRIPTION
This adds a new checkUndervoltage.sh check which will not use the obsolete "vcgencmd" to check for an undervoltage condition anymore but use hmmon related sysfs files instead. This should make the whole thing somewhat less dependent on the vcgencmnd rpi-userland tool which could be soonish retired completely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved under-voltage detection using hardware monitor checks with clearer alarm reporting, yielding more reliable voltage issue identification.

* **Chores**
  * Switched monitoring to the new detection method and removed the legacy dependency; adjusted monitoring behavior for unmonitoring and alarm cycles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->