### PR TITLE
enable checkDisplayPower.sh for other platforms

### DIFF
--- a/buildroot-external/overlay/base/etc/init.d/S01InitHost
+++ b/buildroot-external/overlay/base/etc/init.d/S01InitHost
@@ -81,7 +81,6 @@ identify_host() {
       HM_LED_RED="/sys/class/leds/PWR"
       HM_LED_YELLOW=""
 
-      # if we are running on a raspberrypi we
       # potentially disable the HDMI ports in case
       # no display is connected. This is to save
       # power, but also potential reduce RF interferences
@@ -117,6 +116,12 @@ identify_host() {
       HM_LED_GREEN="/sys/class/leds/blue:status"
       HM_LED_RED=""
       HM_LED_YELLOW=""
+
+      # potentially disable the HDMI ports in case
+      # no display is connected. This is to save
+      # power, but also potential reduce RF interferences
+      # with the GPIO-based Homematic RF modules
+      /bin/checkDisplayPower.sh
     ;;
 
     # ASUS Tinkerboard2/2S platform
@@ -127,6 +132,12 @@ identify_host() {
       HM_LED_GREEN="/sys/class/leds/green:"
       HM_LED_RED="/sys/class/leds/red:"
       HM_LED_YELLOW="/sys/class/leds/yellow:"
+
+      # potentially disable the HDMI ports in case
+      # no display is connected. This is to save
+      # power, but also potential reduce RF interferences
+      # with the GPIO-based Homematic RF modules
+      /bin/checkDisplayPower.sh
     ;;
 
     # OCI platform
@@ -159,11 +170,23 @@ identify_host() {
     # generic-x86_64
     generic-x86_64)
       HM_HOST="generic-x86_64"
+
+      # potentially disable the HDMI ports in case
+      # no display is connected. This is to save
+      # power, but also potential reduce RF interferences
+      # with the GPIO-based Homematic RF modules
+      /bin/checkDisplayPower.sh
     ;;
 
     # generic-aarch64
     generic-aarch64)
       HM_HOST="generic-aarch64"
+
+      # potentially disable the HDMI ports in case
+      # no display is connected. This is to save
+      # power, but also potential reduce RF interferences
+      # with the GPIO-based Homematic RF modules
+      /bin/checkDisplayPower.sh
     ;;
 
     # lxc platform


### PR DESCRIPTION
This enables the checkDisplayPower.sh to be executed on all related hardware platforms where it could also become handy to disable and partly poweroff any connected HDMI/DP, etc. display to save power and potentially reduce RF interferences.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended HDMI power control functionality to additional platforms including ODROID, Tinkerboard, and generic x86_64/ARM systems, ensuring consistent display power management across supported hardware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->