### PR TITLE
fix checkDisplayPower.sh to use wc for edid readout

### DIFF
--- a/buildroot-external/overlay/base-openccu/bin/checkDisplayPower.sh
+++ b/buildroot-external/overlay/base-openccu/bin/checkDisplayPower.sh
@@ -74,7 +74,7 @@ display_connected() {
         [ -f "$c/edid" ] || continue
         EDID_SIZE=$(wc -c < "$c/edid" 2>/dev/null || echo 0)
         if [ "${EDID_SIZE:-0}" -gt 0 ]; then
-          echo $c connected
+          echo "$c connected"
           return 0
         fi
     done

--- a/buildroot-external/overlay/base-openccu/bin/checkDisplayPower.sh
+++ b/buildroot-external/overlay/base-openccu/bin/checkDisplayPower.sh
@@ -18,7 +18,6 @@
 # for the currently active virtual terminal.
 #
 # Requires: DRM-capable kernel with display driver
-
 # Minutes after consoleblank until display PHY powerdown
 DEFAULT_POWERDOWN_MIN=1
 
@@ -54,6 +53,7 @@ send_to_console() {
 # Power off display: prefer fb0/blank (fbdev), fall back to console DPMS.
 # Console DPMS escape: ESC [ 9 ; n ]  with n=1 blank, n=4 powerdown
 display_off() {
+    echo "turning display off"
     if [ -w "$FB_BLANK" ]; then
         echo 4 > "$FB_BLANK" 2>/dev/null && return 0
     fi
@@ -61,6 +61,7 @@ display_off() {
 }
 
 display_on() {
+    echo "turning display on"
     if [ -w "$FB_BLANK" ]; then
         echo 0 > "$FB_BLANK" 2>/dev/null && return 0
     fi
@@ -70,8 +71,14 @@ display_on() {
 display_connected() {
     for c in ${DRM_CONNECTORS}; do
         is_physical_connector "$c" || continue
-        [ -s "$c/edid" ] && return 0
+        [ -f "$c/edid" ] || continue
+        EDID_SIZE=$(wc -c < "$c/edid" 2>/dev/null || echo 0)
+        if [ "${EDID_SIZE:-0}" -gt 0 ]; then
+          echo $c connected
+          return 0
+        fi
     done
+    echo "no display connected"
     return 1
 }
 

--- a/buildroot-external/overlay/base/etc/init.d/S01InitHost
+++ b/buildroot-external/overlay/base/etc/init.d/S01InitHost
@@ -85,7 +85,7 @@ identify_host() {
       # no display is connected. This is to save
       # power, but also potential reduce RF interferences
       # with the GPIO-based Homematic RF modules
-      /bin/checkDisplayPower.sh
+      /bin/checkDisplayPower.sh >/dev/null
 
       # increase vm.min_free_kbytes to 16384 to increase stability
       # in memory critical situations
@@ -121,7 +121,7 @@ identify_host() {
       # no display is connected. This is to save
       # power, but also potential reduce RF interferences
       # with the GPIO-based Homematic RF modules
-      /bin/checkDisplayPower.sh
+      /bin/checkDisplayPower.sh >/dev/null
     ;;
 
     # ASUS Tinkerboard2/2S platform
@@ -137,7 +137,7 @@ identify_host() {
       # no display is connected. This is to save
       # power, but also potential reduce RF interferences
       # with the GPIO-based Homematic RF modules
-      /bin/checkDisplayPower.sh
+      /bin/checkDisplayPower.sh >/dev/null
     ;;
 
     # OCI platform
@@ -175,7 +175,7 @@ identify_host() {
       # no display is connected. This is to save
       # power, but also potential reduce RF interferences
       # with the GPIO-based Homematic RF modules
-      /bin/checkDisplayPower.sh
+      /bin/checkDisplayPower.sh >/dev/null
     ;;
 
     # generic-aarch64
@@ -186,7 +186,7 @@ identify_host() {
       # no display is connected. This is to save
       # power, but also potential reduce RF interferences
       # with the GPIO-based Homematic RF modules
-      /bin/checkDisplayPower.sh
+      /bin/checkDisplayPower.sh >/dev/null
     ;;
 
     # lxc platform


### PR DESCRIPTION
This changes checkDisplayPower.sh to not use "-s" test option to check if the edid sysfs node is larger than 0 bytes, because sysfs always shows zero bytes, however, using wc one can correctly check for edid read-out size to derive the connected status. In addition, some stdout output is now added and thus ignored in S01InitHost.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Display power commands now emit brief status messages when run (e.g., "turning display off/on").

* **Bug Fixes**
  * Improved detection of connected displays for more reliable identification.

* **Chores**
  * Suppressed routine diagnostic output during initialization to reduce boot log verbosity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->