### PR TITLE
rework psplash startup to be able to restart psplash

### DIFF
--- a/buildroot-external/overlay/base/etc/init.d/rcK
+++ b/buildroot-external/overlay/base/etc/init.d/rcK
@@ -4,8 +4,32 @@
 # Stop all init scripts in /etc/init.d
 # executing them in reversed numerical order.
 
-# start psplash
-/usr/bin/psplash -n 2>/dev/null &
+# psplash helpers
+# ---------------------------------------------------------------------------
+psplash_ensure() {
+  # fast path: psplash is already running
+  if pidof psplash >/dev/null 2>&1; then
+    return 0
+  fi
+
+  # psplash is gone - remove a possibly stale FIFO so psplash-write does
+  # not block forever on open() when no reader is attached
+  [ -e /run/psplash_fifo ] && rm -f /run/psplash_fifo
+
+  # (re)start psplash in the background
+  /usr/bin/psplash --no-console-switch >/dev/null 2>&1 &
+
+  return 0
+}
+
+psplash_write() {
+  psplash_ensure || return 0
+  /usr/bin/psplash-write "$@" 2>/dev/null
+}
+# ---------------------------------------------------------------------------
+
+# start psplash (initial) - will be (re)started on demand via psplash_write
+psplash_ensure
 
 # shellcheck disable=SC2045
 for i in $(ls -r /etc/init.d/S??*) ;do
@@ -17,8 +41,8 @@ for i in $(ls -r /etc/init.d/S??*) ;do
   # corresponding level
   name=${i##*/}
   num=${name:1:2}
-  /usr/bin/psplash-write "MSG Stopping ${name:3}..."
-  /usr/bin/psplash-write "PROGRESS $((100-${num#0}))"
+  psplash_write "MSG Stopping ${name:3}..."
+  psplash_write "PROGRESS $((100-${num#0}))"
 
   case "$i" in
     *.sh)
@@ -36,8 +60,8 @@ for i in $(ls -r /etc/init.d/S??*) ;do
   esac
 done
 
-/usr/bin/psplash-write "MSG Rebooting..."
-/usr/bin/psplash-write "PROGRESS 0"
+psplash_write "MSG Rebooting..."
+psplash_write "PROGRESS 0"
 
 # quit psplash
-/usr/bin/psplash-write "QUIT"
+pidof psplash >/dev/null 2>&1 && /usr/bin/psplash-write "QUIT" 2>/dev/null

--- a/buildroot-external/overlay/base/etc/init.d/rcK
+++ b/buildroot-external/overlay/base/etc/init.d/rcK
@@ -19,6 +19,13 @@ psplash_ensure() {
   # (re)start psplash in the background
   /usr/bin/psplash --no-console-switch >/dev/null 2>&1 &
 
+  # wait (briefly) for psplash to set up its FIFO
+  local i=0
+  while [ ! -p /run/psplash_fifo ] && [ "$i" -lt 4 ]; do
+    sleep 0.5 2>/dev/null
+    i=$((i+1))
+  done
+
   return 0
 }
 

--- a/buildroot-external/overlay/base/etc/init.d/rcS
+++ b/buildroot-external/overlay/base/etc/init.d/rcS
@@ -34,6 +34,13 @@ psplash_ensure() {
   # (re)start psplash in the background
   /usr/bin/psplash --no-console-switch >/dev/null 2>&1 &
 
+  # wait (briefly) for psplash to set up its FIFO
+  local i=0
+  while [ ! -p /run/psplash_fifo ] && [ "$i" -lt 4 ]; do
+    sleep 0.5 2>/dev/null
+    i=$((i+1))
+  done
+
   return 0
 }
 

--- a/buildroot-external/overlay/base/etc/init.d/rcS
+++ b/buildroot-external/overlay/base/etc/init.d/rcS
@@ -1,5 +1,5 @@
 #!/bin/sh
-# shellcheck shell=dash disable=SC2169 source=/dev/null
+# shellcheck shell=dash disable=SC2169,SC3010,SC3057,SC3014,SC3036 source=/dev/null
 #
 # Start all init scripts in /etc/init.d
 # executing them in numerical order.
@@ -19,11 +19,34 @@ umask 0002
 # create ld.so.cache file
 /sbin/ldconfig -C /var/cache/ld.so.cache
 
-# start psplash
-/usr/bin/psplash -n 2>/dev/null &
+# psplash helpers
+# ---------------------------------------------------------------------------
+psplash_ensure() {
+  # fast path: psplash is already running
+  if pidof psplash >/dev/null 2>&1; then
+    return 0
+  fi
+
+  # psplash is gone - remove a possibly stale FIFO so psplash-write does
+  # not block forever on open() when no reader is attached
+  [ -e /run/psplash_fifo ] && rm -f /run/psplash_fifo
+
+  # (re)start psplash in the background
+  /usr/bin/psplash --no-console-switch >/dev/null 2>&1 &
+
+  return 0
+}
+
+psplash_write() {
+  psplash_ensure || return 0
+  /usr/bin/psplash-write "$@" 2>/dev/null
+}
+# ---------------------------------------------------------------------------
+
+# start psplash (initial) - will be (re)started on demand via psplash_write
+psplash_ensure
 
 for i in /etc/init.d/S??* ;do
-
   # Ignore dangling symlinks (if any).
   [[ ! -f "${i}" ]] && continue
 
@@ -31,8 +54,8 @@ for i in /etc/init.d/S??* ;do
   # corresponding level
   name=${i##*/}
   num=${name:1:2}
-  /usr/bin/psplash-write "MSG Starting ${name:3}..."
-  /usr/bin/psplash-write "PROGRESS $((${num#0}+1))"
+  psplash_write "MSG Starting ${name:3}..."
+  psplash_write "PROGRESS $((${num#0}+1))"
 
   case "${i}" in
     *.sh)
@@ -46,12 +69,12 @@ for i in /etc/init.d/S??* ;do
     *)
       # No sh extension, so fork subprocess.
       ${i} start
-    ;;
+      ;;
   esac
 done
 
 IP=$(ip -4 route get 1 | head -1 | cut -d' ' -f8 | tr -d '\n')
-/usr/bin/psplash-write "PROGRESS 0"
+psplash_write "PROGRESS 0"
 
 [[ -r /VERSION ]] && . /VERSION
 [[ -r /var/hm_mode ]] && . /var/hm_mode
@@ -73,8 +96,8 @@ else
   fi
 fi
 MSG=$(echo -en "${MSG}\n\n-- Press ALT+F2 for service console")
+psplash_write "MSG ${MSG}"
 
-/usr/bin/psplash-write "MSG ${MSG}"
-
-# quit psplash after 5 seconds
-(sleep 5; /usr/bin/psplash-write "QUIT") &
+# quit psplash after 3 seconds (only if still running - do not restart
+# just to immediately quit)
+(sleep 3; pidof psplash >/dev/null 2>&1 && /usr/bin/psplash-write "QUIT" 2>/dev/null) &

--- a/buildroot-external/package/recovery-system/external/overlay/base/etc/init.d/rcK
+++ b/buildroot-external/package/recovery-system/external/overlay/base/etc/init.d/rcK
@@ -4,6 +4,33 @@
 # Stop all init scripts in /etc/init.d
 # executing them in reversed numerical order.
 
+# psplash helpers
+# ---------------------------------------------------------------------------
+psplash_ensure() {
+  # fast path: psplash is already running
+  if pidof psplash >/dev/null 2>&1; then
+    return 0
+  fi
+
+  # psplash is gone - remove a possibly stale FIFO so psplash-write does
+  # not block forever on open() when no reader is attached
+  [ -e /run/psplash_fifo ] && rm -f /run/psplash_fifo
+
+  # (re)start psplash in the background
+  /usr/bin/psplash --no-console-switch >/dev/null 2>&1 &
+
+  return 0
+}
+
+psplash_write() {
+  psplash_ensure || return 0
+  /usr/bin/psplash-write "$@" 2>/dev/null
+}
+# ---------------------------------------------------------------------------
+
+# start psplash (initial) - will be (re)started on demand via psplash_write
+psplash_ensure
+
 # shellcheck disable=SC2045
 for i in $(ls -r /etc/init.d/S??*) ;do
 
@@ -14,8 +41,8 @@ for i in $(ls -r /etc/init.d/S??*) ;do
   # corresponding level
   name=${i##*/}
   num=${name:1:2}
-  /usr/bin/psplash-write "MSG Stopping ${name:3}..."
-  /usr/bin/psplash-write "PROGRESS $((100-${num#0}))"
+  psplash_write "MSG Stopping ${name:3}..."
+  psplash_write "PROGRESS $((100-${num#0}))"
 
   case "$i" in
     *.sh)
@@ -33,5 +60,8 @@ for i in $(ls -r /etc/init.d/S??*) ;do
   esac
 done
 
-/usr/bin/psplash-write "MSG Rebooting..."
-/usr/bin/psplash-write "PROGRESS 0"
+psplash_write "MSG Rebooting..."
+psplash_write "PROGRESS 0"
+
+# quit psplash
+pidof psplash >/dev/null 2>&1 && /usr/bin/psplash-write "QUIT" 2>/dev/null

--- a/buildroot-external/package/recovery-system/external/overlay/base/etc/init.d/rcK
+++ b/buildroot-external/package/recovery-system/external/overlay/base/etc/init.d/rcK
@@ -19,6 +19,13 @@ psplash_ensure() {
   # (re)start psplash in the background
   /usr/bin/psplash --no-console-switch >/dev/null 2>&1 &
 
+  # wait (briefly) for psplash to set up its FIFO
+  local i=0
+  while [ ! -p /run/psplash_fifo ] && [ "$i" -lt 4 ]; do
+    sleep 0.5 2>/dev/null
+    i=$((i+1))
+  done
+
   return 0
 }
 

--- a/buildroot-external/package/recovery-system/external/overlay/base/etc/init.d/rcS
+++ b/buildroot-external/package/recovery-system/external/overlay/base/etc/init.d/rcS
@@ -1,5 +1,5 @@
 #!/bin/sh
-# shellcheck shell=dash disable=SC2169 source=/dev/null
+# shellcheck shell=dash disable=SC2169,SC3010,SC3057,SC3014,SC3036 source=/dev/null
 #
 # Start all init scripts in /etc/init.d
 # executing them in numerical order.
@@ -7,14 +7,46 @@
 # make sure we have a secure umask
 umask 0002
 
-# Parameters (default values)
-RECOVERY_SPLASHSCREEN_TITLE="CCU Recovery"
+# perform systemwide fsck
+/sbin/fsck -A -R -p
 
-# Load product specific parameters  
-[[ -r /etc/product ]] && . /etc/product
+# mount all filesystems
+/bin/mount -a
+
+# create /var/run and /var/cache
+/bin/mkdir -p /var/run /var/cache
+
+# create ld.so.cache file
+/sbin/ldconfig -C /var/cache/ld.so.cache
+
+# psplash helpers
+# ---------------------------------------------------------------------------
+psplash_ensure() {
+  # fast path: psplash is already running
+  if pidof psplash >/dev/null 2>&1; then
+    return 0
+  fi
+
+  # psplash is gone - remove a possibly stale FIFO so psplash-write does
+  # not block forever on open() when no reader is attached
+  [ -e /run/psplash_fifo ] && rm -f /run/psplash_fifo
+
+  # (re)start psplash in the background
+  /usr/bin/psplash --no-console-switch >/dev/null 2>&1 &
+
+  return 0
+}
+
+psplash_write() {
+  psplash_ensure || return 0
+  /usr/bin/psplash-write "$@" 2>/dev/null
+}
+# ---------------------------------------------------------------------------
+
+# start psplash (initial) - will be (re)started on demand via psplash_write
+psplash_ensure
 
 for i in /etc/init.d/S??* ;do
-
   # Ignore dangling symlinks (if any).
   [[ ! -f "${i}" ]] && continue
 
@@ -22,8 +54,8 @@ for i in /etc/init.d/S??* ;do
   # corresponding level
   name=${i##*/}
   num=${name:1:2}
-  /usr/bin/psplash-write "MSG Starting ${name:3}..."
-  /usr/bin/psplash-write "PROGRESS $((${num#0}+1))"
+  psplash_write "MSG Starting ${name:3}..."
+  psplash_write "PROGRESS $((${num#0}+1))"
 
   case "${i}" in
     *.sh)
@@ -37,21 +69,26 @@ for i in /etc/init.d/S??* ;do
     *)
       # No sh extension, so fork subprocess.
       ${i} start
-    ;;
+      ;;
   esac
 done
 
 IP=$(ip -4 route get 1 | head -1 | cut -d' ' -f8 | tr -d '\n')
-/usr/bin/psplash-write "PROGRESS 0"
+psplash_write "PROGRESS 0"
 
 [[ -r /VERSION ]] && . /VERSION
 
-MSG="${RECOVERY_SPLASHSCREEN_TITLE} ${VERSION} --"
+echo "Finished Boot: ${VERSION} (${PRODUCT})"
+
+MSG="OpenCCU Recovery ${VERSION} --"
 if [[ -z "${IP}" ]]; then
   MSG="${MSG} ERROR: No IP address set"
 else
-  MSG="${MSG} Open http://${IP}/ in browser"
+  MSG="${MSG} http://${IP}/"
 fi
 MSG=$(echo -en "${MSG}\n\n-- Press ALT+F2 for service console")
+psplash_write "MSG ${MSG}"
 
-/usr/bin/psplash-write "MSG ${MSG}"
+# quit psplash after 3 seconds (only if still running - do not restart
+# just to immediately quit)
+(sleep 3; pidof psplash >/dev/null 2>&1 && /usr/bin/psplash-write "QUIT" 2>/dev/null) &

--- a/buildroot-external/package/recovery-system/external/overlay/base/etc/init.d/rcS
+++ b/buildroot-external/package/recovery-system/external/overlay/base/etc/init.d/rcS
@@ -34,6 +34,13 @@ psplash_ensure() {
   # (re)start psplash in the background
   /usr/bin/psplash --no-console-switch >/dev/null 2>&1 &
 
+  # wait (briefly) for psplash to set up its FIFO
+  local i=0
+  while [ ! -p /run/psplash_fifo ] && [ "$i" -lt 4 ]; do
+    sleep 0.5 2>/dev/null
+    i=$((i+1))
+  done
+
   return 0
 }
 

--- a/buildroot-external/package/recovery-system/external/overlay/base/etc/inittab
+++ b/buildroot-external/package/recovery-system/external/overlay/base/etc/inittab
@@ -13,18 +13,15 @@
 # action    == one of sysinit, respawn, askfirst, wait, and once
 # process   == program to run
 
-# Startup the system
+# Init the system
 tty2::sysinit:/bin/mount /proc
 tty2::sysinit:/bin/mount /sys
+tty2::sysinit:/bin/mount /tmp
 tty2::sysinit:/bin/mkdir -p /dev/pts /dev/shm
-tty2::sysinit:/sbin/fsck -A -R -p
-tty2::sysinit:/bin/mount -a
-tty2::sysinit:/bin/mkdir -p /var/run
-tty2::sysinit:/bin/mkdir -p /var/cache
-tty2::sysinit:/sbin/ldconfig -C /var/cache/ld.so.cache
-null::sysinit:/usr/bin/psplash -n &
-# now run any rc scripts
-::sysinit:/etc/init.d/rcS
+
+# run any rc scripts (start) and move boot.log
+::sysinit:/etc/init.d/rcS 2>&1 | /usr/bin/tee -a /tmp/boot.log
+::sysinit:/bin/mv /tmp/boot.log /var/log/boot.log
 
 # Put a getty on tty2
 tty2::askfirst:/sbin/getty -L tty2 0 vt100
@@ -32,7 +29,9 @@ tty2::askfirst:/sbin/getty -L tty2 0 vt100
 # Stuff to do for the 3-finger salute
 ::ctrlaltdel:/sbin/reboot
 
-# Stuff to do before rebooting
+# run any rc scripts (stop)
 ::shutdown:/etc/init.d/rcK
+
+# cleanup system
 tty2::shutdown:/bin/umount -a -r -f >/dev/null
 tty2::shutdown:/sbin/swapoff -a


### PR DESCRIPTION
This adds psplash helper functions to rcS/rcK init files which ensure that psplash will run as soon as psplash write commands are executed. This should fix issues where psplash might not be able to start early enough due to framebuffer switch-over when DRM comes up. Now each write command will ensure that psplash runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved boot splash reliability and robustness (better handling of stale IPC and conditional shutdown)
  * Consolidated splash messaging to avoid noisy errors during startup/shutdown
  * Added boot sequence logging to capture init output for diagnostics
  * Refined initialization and shutdown ordering for more predictable startup/shutdown behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->