### PR TITLE
bump rpi-eeprom to 57c17bc

### DIFF
--- a/buildroot-external/package/rpi-eeprom/rpi-eeprom.hash
+++ b/buildroot-external/package/rpi-eeprom/rpi-eeprom.hash
@@ -1,3 +1,3 @@
 # Locally computed
 sha256  594b7565fd3ccf8acd4711a2ec1b199181aafbc3426d0bacaa50ef40edbf7c4a  LICENSE
-sha256  c77ea4d476cdeb505033b311dbe08ee0eb5b1ec7617e962fa709d67784e81fe1  rpi-eeprom-85c834683d380c3ce2254c6cb0c79ee6ee737b78.tar.gz
+sha256  1df465cd8f5bed018406d346e373f2b1cb318a271e675aecc8c744bb99e22007  rpi-eeprom-57c17bc03d8558c96420961aa6cb40d50df0cfaf.tar.gz

--- a/buildroot-external/package/rpi-eeprom/rpi-eeprom.mk
+++ b/buildroot-external/package/rpi-eeprom/rpi-eeprom.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-RPI_EEPROM_VERSION = 85c834683d380c3ce2254c6cb0c79ee6ee737b78
+RPI_EEPROM_VERSION = 57c17bc03d8558c96420961aa6cb40d50df0cfaf
 RPI_EEPROM_SITE = $(call github,raspberrypi,rpi-eeprom,$(RPI_EEPROM_VERSION))
 RPI_EEPROM_LICENSE = BSD-3-Clause, MIT, uIP, custom
 RPI_EEPROM_LICENSE_FILES = LICENSE
@@ -17,7 +17,7 @@ ifeq ($(BR2_PACKAGE_RPI_EEPROM_RPI4),y)
   RPI_EEPROM_VL805_GLOB = firmware-2711/stable/vl805-*.bin
 else ifeq ($(BR2_PACKAGE_RPI_EEPROM_RPI5),y)
   # Raspberry Pi 5 (2712)
-  RPI_EEPROM_FIRMWARE_PATH = firmware-2712/stable/pieeprom-2026-04-14.bin
+  RPI_EEPROM_FIRMWARE_PATH = firmware-2712/stable/pieeprom-2026-04-27.bin
   RPI_EEPROM_RECOVERY_PATH = firmware-2712/stable/recovery.bin
 endif
 


### PR DESCRIPTION
Dependency update generated by nightly update check workflow.

Updated component:
- Name...: `rpi-eeprom`
- Package: `rpi-eeprom`
- Current version: `85c8346`
- New version....: `57c17bc`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Raspberry Pi EEPROM package to a newer version.
  * Updated the Raspberry Pi 5 firmware binary to a more recent release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->