### PR TITLE
fix USB hotplug on ODROID-C2.

### DIFF
--- a/buildroot-external/board/odroid-c2/kernel.config
+++ b/buildroot-external/board/odroid-c2/kernel.config
@@ -1,1 +1,9 @@
-../odroid-n2/kernel.config
+CONFIG_I2C=y
+CONFIG_I2C_MESON=y
+
+CONFIG_DRM=y
+CONFIG_DRM_MESON=y
+CONFIG_DRM_MESON_DW_HDMI=y
+
+# disable autosuspend (cf. https://github.com/home-assistant/operating-system/pull/4669)
+CONFIG_USB_AUTOSUSPEND_DELAY=-1


### PR DESCRIPTION
This disables the USB autosuspend feature for ODROID-C2 because USB autosuspend interacting badly with dwc2 on Meson-GXBB causing USB hotplug to fail.

(cf. https://github.com/home-assistant/operating-system/pull/4669)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * I2C device support is now enabled for hardware communication
  * Display and HDMI output support is now enabled
  * USB devices will remain powered and won't enter low-power mode

<!-- end of auto-generated comment: release notes by coderabbit.ai -->