### PR TITLE
fix start/stop delays for headless systems

### DIFF
--- a/buildroot-external/overlay/base/etc/init.d/rcK
+++ b/buildroot-external/overlay/base/etc/init.d/rcK
@@ -7,6 +7,11 @@
 # psplash helpers
 # ---------------------------------------------------------------------------
 psplash_ensure() {
+  # continue only if /dev/fb0 exists
+  if [ ! -c /dev/fb0 ]; then
+    return 0
+  fi
+
   # fast path: psplash is already running
   if pidof psplash >/dev/null 2>&1; then
     return 0

--- a/buildroot-external/overlay/base/etc/init.d/rcS
+++ b/buildroot-external/overlay/base/etc/init.d/rcS
@@ -22,6 +22,11 @@ umask 0002
 # psplash helpers
 # ---------------------------------------------------------------------------
 psplash_ensure() {
+  # continue only if /dev/fb0 exists
+  if [ ! -c /dev/fb0 ]; then
+    return 0
+  fi
+
   # fast path: psplash is already running
   if pidof psplash >/dev/null 2>&1; then
     return 0

--- a/buildroot-external/package/recovery-system/external/overlay/base/etc/init.d/rcK
+++ b/buildroot-external/package/recovery-system/external/overlay/base/etc/init.d/rcK
@@ -7,6 +7,11 @@
 # psplash helpers
 # ---------------------------------------------------------------------------
 psplash_ensure() {
+  # continue only if /dev/fb0 exists
+  if [ ! -c /dev/fb0 ]; then
+    return 0
+  fi
+
   # fast path: psplash is already running
   if pidof psplash >/dev/null 2>&1; then
     return 0

--- a/buildroot-external/package/recovery-system/external/overlay/base/etc/init.d/rcS
+++ b/buildroot-external/package/recovery-system/external/overlay/base/etc/init.d/rcS
@@ -22,6 +22,11 @@ umask 0002
 # psplash helpers
 # ---------------------------------------------------------------------------
 psplash_ensure() {
+  # continue only if /dev/fb0 exists
+  if [ ! -c /dev/fb0 ]; then
+    return 0
+  fi
+
   # fast path: psplash is already running
   if pidof psplash >/dev/null 2>&1; then
     return 0


### PR DESCRIPTION
This change adds dedicated /dev/fb0 checks in rcS/rcK init startup scripts which should ensure that no unnecessary time delays occur when a system is running without any connected display, thus in headless mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified splash screen startup sequence to verify display device availability before initialization, preventing startup attempts on systems lacking framebuffer support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->