### PR TITLE
start irqbalance on non-virt platforms only

### DIFF
--- a/buildroot-external/overlay/base-openccu/etc/monitrc
+++ b/buildroot-external/overlay/base-openccu/etc/monitrc
@@ -83,7 +83,7 @@ check process irqbalance with pidfile /var/run/irqbalance.pid
       exec "/bin/triggerAlarm.tcl 'irqbalance: high filedescriptor usage (>95%)' 'WatchDog: irqbalance-highfd' true"
     depends on irqbalanceEnabled
 
-check program irqbalanceEnabled with path /bin/sh -c "/usr/bin/test $(nproc) -gt 1"
+check program irqbalanceEnabled with path "/bin/sh -c '/usr/bin/test $(nproc) -gt 1 && ! /usr/bin/lscpu | grep -q Hypervisor\\ vendor:'"
     group system
     if status != 0 for 1 cycles then unmonitor
 

--- a/buildroot-external/overlay/base/etc/init.d/S13irqbalance
+++ b/buildroot-external/overlay/base/etc/init.d/S13irqbalance
@@ -1,8 +1,11 @@
 #!/bin/sh
-# shellcheck shell=dash disable=SC2169
+# shellcheck shell=dash disable=SC2169,SC3010
 #
 # Starts irqbalance
 #
+
+# skip irqbalance on virtualized environments
+/usr/bin/lscpu | grep -q "Hypervisor vendor:" && exit 0
 
 # skip irqbalance use for systems with less than
 # 2 cpus/cores
@@ -16,26 +19,26 @@ ARGS="--foreground"
 PID="/var/run/irqbalance.pid"
 
 case "$1" in
-    start)
-	printf "Starting irqbalance: "
-	# shellcheck disable=SC2086
-	if ! start-stop-daemon -S -q -b -m -p ${PID} --exec $EXEC -- $ARGS; then
-	    echo "FAILED"
-	    exit 1
-	else
-	    echo "OK"
-	fi
-	;;
-    stop)
-	printf "Stopping irqbalance: "
-	start-stop-daemon -K -q -p ${PID}
-	echo "OK"
-	;;
-    restart|reload)
-	$0 stop
-	$0 start
-	;;
-    *)
-	echo "Usage: $0 {start|stop|restart}"
-	exit 1
+  start)
+    printf "Starting irqbalance: "
+    # shellcheck disable=SC2086
+    if ! start-stop-daemon -S -q -b -m -p ${PID} --exec $EXEC -- $ARGS; then
+      echo "FAILED"
+      exit 1
+    else
+      echo "OK"
+    fi
+    ;;
+  stop)
+    printf "Stopping irqbalance: "
+    start-stop-daemon -K -q -p ${PID}
+    echo "OK"
+    ;;
+  restart|reload)
+    $0 stop
+    $0 start
+    ;;
+  *)
+    echo "Usage: $0 {start|stop|restart}"
+    exit 1
 esac


### PR DESCRIPTION
This changes the S13irqbalance init script and the monitrc file to ensure that the irqbalance daemon will only be started in environments where no virtualization is involved since the irqbalance functionality only consistently work on real hardware environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced system resource management for virtualized environments. The irqbalance service now includes improved virtualization detection and will automatically disable itself when running on virtual systems or cloud platforms. This change reduces unnecessary system overhead and improves stability across all virtualized deployments while maintaining full functionality on physical systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->