### PR TITLE
improved monitrc for service checks reliance

### DIFF
--- a/buildroot-external/overlay/base-openccu/etc/monitrc
+++ b/buildroot-external/overlay/base-openccu/etc/monitrc
@@ -243,7 +243,7 @@ check process hs485d with pidfile /var/run/hs485dLoader.pid
       exec "/bin/triggerAlarm.tcl 'hs485d: high filedescriptor usage (>95%)' 'WatchDog: hs485d-highfd' true"
     depends on hs485dEnabled, hmlangwDisabled
 
-check program hs485dEnabled with path "/bin/grep -q '^\[Interface .\]' /var/etc/hs485d.conf"
+check program hs485dEnabled with path /bin/sh -c "/bin/grep -q '^\[Interface .\]' /var/etc/hs485d.conf 2>/dev/null"
     group homematic
     if status != 0 for 1 cycles then unmonitor
 
@@ -378,7 +378,7 @@ check filesystem usb1 with path /media/usb1
 
 check program hasUSB with path "/usr/bin/test -e /var/status/hasUSB"
     group system
-    if status != 0 for 5 cycles then unmonitor
+    if status != 0 for 1 cycles then unmonitor
 
 # check system temperature limits
 check program temperature with path /bin/sh -c "(cat /sys/class/thermal/thermal_zone0/temp 2>/dev/null || echo 0) | awk '{ print $1/1000; if($1/1000 < 80.0) { exit 10 } else { exit 20 } }';"
@@ -419,7 +419,7 @@ check program wlan0CheckEnabled with path /bin/sh -c "[[ -e /etc/config/wpa_supp
 # monitor under-voltage condition (RaspberryPi only)
 check program underVoltageCheck with path "/bin/checkUndervoltage.sh"
     group system
-    if status = 1 for 3 cycles then unmonitor
+    if status = 1 for 1 cycles then unmonitor
     if status = 2 for 2 cycles then
       exec "/bin/triggerAlarm.tcl 'under-voltage detected' 'WatchDog: low-voltage' true"
       repeat every 24 cycles
@@ -474,7 +474,7 @@ check program coProcessorCheck with path "/bin/checkCoProcessor.sh"
 # check remaining eMMC life-time
 check program eMMCLifeTimeCheck with path "/bin/checkEMMCLifeTime.sh"
     group system
-    if status = 1 for 3 cycles then unmonitor
+    if status = 1 for 1 cycles then unmonitor
     if status = 2 for 5 cycles then
       exec "/bin/triggerAlarm.tcl 'eMMC life time >90% exceeded' 'WatchDog: emmc-lifetime90' true"
       repeat every 280 cycles
@@ -485,7 +485,7 @@ check program eMMCLifeTimeCheck with path "/bin/checkEMMCLifeTime.sh"
 # check if a pi4 with usb3+gpio rf module is used
 check program rpi4usb3Check with path "/bin/checkRpi4Usb3.sh"
     group system
-    if status = 1 for 3 cycles then unmonitor
+    if status = 1 for 1 cycles then unmonitor
     if status = 2 for 5 cycles then
       exec "/bin/triggerAlarm.tcl 'Critical RaspberryPi4+USB3+GPIO use detected' 'WatchDog: rpi4-usb3' true"
       repeat every 24 cycles

--- a/buildroot-external/overlay/base-openccu_lxc/etc/monitrc
+++ b/buildroot-external/overlay/base-openccu_lxc/etc/monitrc
@@ -118,7 +118,7 @@ check process hs485d with pidfile /var/run/hs485dLoader.pid
       exec "/bin/triggerAlarm.tcl 'hs485d: high filedescriptor usage (>95%)' 'WatchDog: hs485d-highfd' true"
     depends on hs485dEnabled, hmlangwDisabled
 
-check program hs485dEnabled with path "/bin/grep -q '^\[Interface .\]' /var/etc/hs485d.conf"
+check program hs485dEnabled with path /bin/sh -c "/bin/grep -q '^\[Interface .\]' /var/etc/hs485d.conf 2>/dev/null"
     group homematic
     if status != 0 for 1 cycles then unmonitor
 
@@ -253,7 +253,7 @@ check filesystem usb1 with path /media/usb1
 
 check program hasUSB with path "/usr/bin/test -e /var/status/hasUSB"
     group system
-    if status != 0 for 5 cycles then unmonitor
+    if status != 0 for 1 cycles then unmonitor
 
 # check system temperature limits
 check program temperature with path /bin/sh -c "(cat /sys/class/thermal/thermal_zone0/temp 2>/dev/null || echo 0) | awk '{ print $1/1000; if($1/1000 < 80.0) { exit 10 } else { exit 20 } }';"
@@ -304,7 +304,7 @@ check program coProcessorCheck with path "/bin/checkCoProcessor.sh"
 # check if a pi4 with usb3+gpio rf module is used
 check program rpi4usb3Check with path "/bin/checkRpi4Usb3.sh"
     group system
-    if status = 1 for 3 cycles then unmonitor
+    if status = 1 for 1 cycles then unmonitor
     if status = 2 for 5 cycles then
       exec "/bin/triggerAlarm.tcl 'Critical RaspberryPi4+USB3+GPIO use detected' 'WatchDog: rpi4-usb3' true"
       repeat every 24 cycles

--- a/buildroot-external/overlay/base-openccu_oci/etc/monitrc
+++ b/buildroot-external/overlay/base-openccu_oci/etc/monitrc
@@ -134,7 +134,7 @@ check process hs485d with pidfile /var/run/hs485dLoader.pid
       exec "/bin/triggerAlarm.tcl 'hs485d: high filedescriptor usage (>95%)' 'WatchDog: hs485d-highfd' true"
     depends on hs485dEnabled, hmlangwDisabled
 
-check program hs485dEnabled with path "/bin/grep -q '^\[Interface .\]' /var/etc/hs485d.conf"
+check program hs485dEnabled with path /bin/sh -c "/bin/grep -q '^\[Interface .\]' /var/etc/hs485d.conf 2>/dev/null"
     group homematic
     if status != 0 for 1 cycles then unmonitor
 
@@ -269,7 +269,7 @@ check filesystem usb1 with path /media/usb1
 
 check program hasUSB with path "/usr/bin/test -e /var/status/hasUSB"
     group system
-    if status != 0 for 5 cycles then unmonitor
+    if status != 0 for 1 cycles then unmonitor
 
 # check system temperature limits
 check program temperature with path /bin/sh -c "(cat /sys/class/thermal/thermal_zone0/temp 2>/dev/null || echo 0) | awk '{ print $1/1000; if($1/1000 < 80.0) { exit 10 } else { exit 20 } }';"
@@ -320,7 +320,7 @@ check program coProcessorCheck with path "/bin/checkCoProcessor.sh"
 # check if a pi4 with usb3+gpio rf module is used
 check program rpi4usb3Check with path "/bin/checkRpi4Usb3.sh"
     group system
-    if status = 1 for 3 cycles then unmonitor
+    if status = 1 for 1 cycles then unmonitor
     if status = 2 for 5 cycles then
       exec "/bin/triggerAlarm.tcl 'Critical RaspberryPi4+USB3+GPIO use detected' 'WatchDog: rpi4-usb3' true"
       repeat every 24 cycles

--- a/buildroot-external/overlay/base/etc/usbmount/mount.d/01_create_statusfile
+++ b/buildroot-external/overlay/base/etc/usbmount/mount.d/01_create_statusfile
@@ -13,3 +13,8 @@ fi
 touch /var/status/hasUSB
 # CCU2 compatibility 
 touch /var/status/hasSD
+
+# trigger monit to check
+# for USB changes again
+/usr/bin/monit monitor hasUSB
+/usr/bin/monit monitor usb1


### PR DESCRIPTION
This modifies the /etc/monitrc to ensure that an unmonitor action will take place after 1 cycle already if the check is a simple enable check. This should make the enabled checking a bit faster. In addition hs485d config checking will now be performed with quiet hs485d.conf checking and the usbmount 01_create_statusfile will now trigger a hasUSB and usb1 monit service rechecking upon creating the hasUSB file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Accelerated USB device connectivity detection by optimizing monitoring check intervals, enabling faster system responses when USB devices are disconnected or become unavailable
  * Enhanced error tolerance for device configuration checks to gracefully handle temporarily unavailable configuration files without impacting overall monitoring operations
  * Improved device state monitoring responsiveness across multiple system deployment configurations, ensuring quicker detection and reaction to device status changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->