### PR TITLE
re-renable irqbalance on multi-core virtual platforms

### DIFF
--- a/buildroot-external/overlay/base-openccu/etc/monitrc
+++ b/buildroot-external/overlay/base-openccu/etc/monitrc
@@ -83,7 +83,7 @@ check process irqbalance with pidfile /var/run/irqbalance.pid
       exec "/bin/triggerAlarm.tcl 'irqbalance: high filedescriptor usage (>95%)' 'WatchDog: irqbalance-highfd' true"
     depends on irqbalanceEnabled
 
-check program irqbalanceEnabled with path "/bin/sh -c '/usr/bin/test $(nproc) -gt 1'"
+check program irqbalanceEnabled with path "/bin/sh -c '/usr/bin/test $(/usr/bin/nproc) -gt 1'"
     group system
     if status != 0 for 1 cycles then unmonitor
 

--- a/buildroot-external/overlay/base-openccu/etc/monitrc
+++ b/buildroot-external/overlay/base-openccu/etc/monitrc
@@ -83,7 +83,7 @@ check process irqbalance with pidfile /var/run/irqbalance.pid
       exec "/bin/triggerAlarm.tcl 'irqbalance: high filedescriptor usage (>95%)' 'WatchDog: irqbalance-highfd' true"
     depends on irqbalanceEnabled
 
-check program irqbalanceEnabled with path "/bin/sh -c '/usr/bin/test $(nproc) -gt 1 && ! /usr/bin/lscpu | grep -q Hypervisor\\ vendor:'"
+check program irqbalanceEnabled with path "/bin/sh -c '/usr/bin/test $(nproc) -gt 1'"
     group system
     if status != 0 for 1 cycles then unmonitor
 

--- a/buildroot-external/overlay/base/etc/init.d/S13irqbalance
+++ b/buildroot-external/overlay/base/etc/init.d/S13irqbalance
@@ -4,9 +4,6 @@
 # Starts irqbalance
 #
 
-# skip irqbalance on virtualized environments
-/usr/bin/lscpu | grep -q "Hypervisor vendor:" && exit 0
-
 # skip irqbalance use for systems with less than
 # 2 cpus/cores
 [[ $(nproc) -lt 2 ]] && exit 0

--- a/buildroot-external/overlay/base/etc/init.d/S13irqbalance
+++ b/buildroot-external/overlay/base/etc/init.d/S13irqbalance
@@ -6,7 +6,7 @@
 
 # skip irqbalance use for systems with less than
 # 2 cpus/cores
-[[ $(nproc) -lt 2 ]] && exit 0
+[[ $(/usr/bin/nproc) -lt 2 ]] && exit 0
 
 # irqbalance requires /run/irqbalance
 mkdir -p /run/irqbalance


### PR DESCRIPTION
This re-enables the start/operation of irqbalance even on virtual platforms (e.g. OVA) which might potentially slightly benefit from assigning certain I/O workloads to different vCPUs. Thus, only pure virtual platforms like OCI/LXC platforms still don't use irqbalance and thus this service is completly disabled there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * IRQ balancing service startup no longer skips on virtualized hosts; activation is now determined solely by CPU/core count.
  * Monitoring for the IRQ balancing service follows the same CPU-based rule, ensuring consistent start and monitoring behavior across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->