### PR TITLE
bump rpi-eeprom to 3e167bc

### DIFF
--- a/buildroot-external/package/rpi-eeprom/rpi-eeprom.hash
+++ b/buildroot-external/package/rpi-eeprom/rpi-eeprom.hash
@@ -1,3 +1,3 @@
 # Locally computed
 sha256  594b7565fd3ccf8acd4711a2ec1b199181aafbc3426d0bacaa50ef40edbf7c4a  LICENSE
-sha256  0b194f543ae704f98567ce6a862b4c4476669d47018caee0f8847ed5bd678962  rpi-eeprom-1249dd937d06bbff58da60e8c69985a403be04ec.tar.gz
+sha256  36dc2856778666bd2a95e2afcd51eb7ed18d78adadadfdb77efb79ed3bc44621  rpi-eeprom-3e167bc89624e0b65584fe1cd2a1f432cc3e1cac.tar.gz

--- a/buildroot-external/package/rpi-eeprom/rpi-eeprom.mk
+++ b/buildroot-external/package/rpi-eeprom/rpi-eeprom.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-RPI_EEPROM_VERSION = 1249dd937d06bbff58da60e8c69985a403be04ec
+RPI_EEPROM_VERSION = 3e167bc89624e0b65584fe1cd2a1f432cc3e1cac
 RPI_EEPROM_SITE = $(call github,raspberrypi,rpi-eeprom,$(RPI_EEPROM_VERSION))
 RPI_EEPROM_LICENSE = BSD-3-Clause, MIT, uIP, custom
 RPI_EEPROM_LICENSE_FILES = LICENSE


### PR DESCRIPTION
Dependency update generated by nightly update check workflow.

Updated component:
- Name...: `rpi-eeprom`
- Package: `rpi-eeprom`
- Current version: `1249dd9`
- New version....: `3e167bc`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the RPi EEPROM firmware package version and build system configurations to match the latest upstream release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->