### PR TITLE
bump wiringpi-rpi to v3.19

### DIFF
--- a/buildroot-external/package/wiringpi-rpi/wiringpi-rpi.hash
+++ b/buildroot-external/package/wiringpi-rpi/wiringpi-rpi.hash
@@ -1,3 +1,3 @@
 # Locally computed
 sha256  da7eabb7bafdf7d3ae5e9f223aa5bdc1eece45ac569dc21b3b037520b4464768  COPYING.LESSER
-sha256  c7a06c462372df1650219a10cdd4e8e1da763a41399539ecd1ee1dd4e14e09a8  wiringpi-rpi-3.18.tar.gz
+sha256  a4ae0b7a1094076dd11f40861665aadf7281ab8d5d56fe3451ce5edc6a68e5d9  wiringpi-rpi-v3.19.tar.gz

--- a/buildroot-external/package/wiringpi-rpi/wiringpi-rpi.mk
+++ b/buildroot-external/package/wiringpi-rpi/wiringpi-rpi.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-WIRINGPI_RPI_VERSION = 3.18
+WIRINGPI_RPI_VERSION = v3.19
 WIRINGPI_RPI_SITE = $(call github,wiringpi,wiringpi,$(WIRINGPI_RPI_VERSION))
 
 WIRINGPI_RPI_LICENSE = LGPL-3.0+


### PR DESCRIPTION
Dependency update generated by nightly update check workflow.

Updated component:
- Name...: `wiringpi-rpi`
- Package: `wiringpi-rpi`
- Current version: `3.18`
- New version....: `v3.19`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated WiringPi RPi library to version v3.19 with revised checksums to ensure package integrity and security validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenCCU/OpenCCU/pull/3843)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->