### PR TITLE
bump default disk and memory limits for LXC and OVA

### DIFF
--- a/buildroot-external/board/ova/template.ovf
+++ b/buildroot-external/board/ova/template.ovf
@@ -5,7 +5,7 @@
   </References>
   <DiskSection>
     <Info>Virtual disk information</Info>
-    <Disk ovf:capacity="64" ovf:capacityAllocationUnits="byte * 2^30" ovf:diskId="vmdisk1" ovf:fileRef="file1" ovf:format="http://www.vmware.com/interfaces/specifications/vmdk.html#streamOptimized" ovf:boot="True" vbox:uuid="ac5660a0-9300-457e-a3e1-fd2cc60830f1"/>
+    <Disk ovf:capacity="6" ovf:capacityAllocationUnits="byte * 2^30" ovf:diskId="vmdisk1" ovf:fileRef="file1" ovf:format="http://www.vmware.com/interfaces/specifications/vmdk.html#streamOptimized" ovf:boot="True" vbox:uuid="ac5660a0-9300-457e-a3e1-fd2cc60830f1"/>
   </DiskSection>
   <NetworkSection>
     <Info>The list of logical networks</Info>

--- a/scripts/install-lxc.sh
+++ b/scripts/install-lxc.sh
@@ -22,7 +22,7 @@ trap die ERR
 trap cleanup EXIT
 
 # Set default variables
-VERSION="1.22"
+VERSION="1.23"
 LOGFILE="/tmp/install-lxc.log"
 LINE=
 
@@ -685,7 +685,7 @@ done
 
 # Request memory limits (requires cgroup memory)
 MIN_MEM=1024
-NUM_MEM=${MIN_MEM}
+NUM_MEM=2048
 while true; do
   if NUM_MEM=$(whiptail --inputbox "Please enter the memory limit to assign to the container (minimum is ${MIN_MEM} MiB)" 9 58 ${NUM_MEM} --title "Memory limit request" 3>&1 1>&2 2>&3); then
     if [[ -z "${NUM_MEM}" ]]; then

--- a/scripts/install-proxmox.sh
+++ b/scripts/install-proxmox.sh
@@ -24,7 +24,7 @@ trap die ERR
 trap cleanup EXIT
 
 # Set default variables
-VERSION="3.20"
+VERSION="3.21"
 LOGFILE="/tmp/install-proxmox.log"
 LINE=
 
@@ -704,8 +704,8 @@ info "Using '${STORAGE}' for storage location."
 
 # Select storage size
 info "Selecting virtual disk size"
-DISK_MINSIZE=4
-DISK_CURSIZE=6
+DISK_MINSIZE=6
+DISK_CURSIZE=8
 while true; do
   if DISK_SIZE=$(whiptail --inputbox "Please enter the virtual disk size (GB) for the OpenCCU ${VMTYPE} (minimum is ${DISK_MINSIZE} GB)" 8 58 ${DISK_CURSIZE} --title "Virtual disk size" 3>&1 1>&2 2>&3); then
     if [[ -z "${DISK_SIZE}" ]]; then
@@ -820,7 +820,7 @@ if [[ "${VMTYPE}" == "VM" ]]; then
     info "Creating VM ${VMID}..."
     qm create ${VMID} -bios ovmf \
                       -cores 2 \
-                      -memory 1024 \
+                      -memory 2048 \
                       -name "OpenCCU"
 
     # create EFI disk
@@ -910,7 +910,7 @@ elif [[ "${VMTYPE}" == "CT" ]]; then
     --net0 name=eth0,bridge=vmbr0,ip=dhcp \
     --unprivileged 0 \
     --ostype unmanaged \
-    --memory 1024 \
+    --memory 2048 \
     --rootfs volume=${STORAGE}:1,mountoptions=noatime \
     --mp0 volume=${STORAGE}:${DISK_SIZE},mp=/usr/local,mountoptions=noatime \
     --description "[![OpenCCU](https://raw.githubusercontent.com/OpenCCU/OpenCCU/master/release/logo.png 'OpenCCU')](https://openccu.de)" \


### PR DESCRIPTION
This bumps the default disk and memory limits for the LXC and OVA target installation scripts and default template.ovf to appropriate defaults.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Updates**
  * Increased default memory allocations to 2048MB for container and virtual machine creation
  * Updated OpenCCU to version 3.21
  * Adjusted virtual disk sizing requirements and defaults
  * Updated installer version to 1.23 with revised configuration settings

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenCCU/OpenCCU/pull/3852)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->