### PR TITLE
use timeout command option in docker commands

### DIFF
--- a/scripts/install-docker.sh
+++ b/scripts/install-docker.sh
@@ -3,7 +3,7 @@
 # Script to install the OpenCCU container and its dependencies
 # https://github.com/OpenCCU/OpenCCU/wiki/en.Installation-Docker-OCI
 #
-# Copyright (c) 2022-2024 Jens Maus <mail@jens-maus.de>
+# Copyright (c) 2022-2026 Jens Maus <mail@jens-maus.de>
 # Apache 2.0 License applies
 #
 # Usage:
@@ -71,7 +71,7 @@ alias die='EXIT=$? LINE=${LINENO} error_exit'
 trap die ERR
 
 # Set default variables
-VERSION="1.16"
+VERSION="1.17"
 LINE=
 
 error_exit() {
@@ -119,7 +119,7 @@ uninstall() {
   check_sudo
   if docker container inspect "${CCU_CONTAINER_NAME}" >/dev/null 2>&1; then
     msg "Removing ${CCU_CONTAINER_NAME} container (not user data)"
-    docker stop --time 120 "${CCU_CONTAINER_NAME}" >/dev/null || true
+    docker stop --timeout 120 "${CCU_CONTAINER_NAME}" >/dev/null || true
     docker rm "${CCU_CONTAINER_NAME}" >/dev/null || true
   fi
   if docker network inspect "${CCU_NETWORK_NAME}" >/dev/null 2>&1; then
@@ -211,7 +211,7 @@ cidr2network() {
 #############################################################
 
 msg "OpenCCU Docker installation script v${VERSION}"
-msg "Copyright (c) 2022-2024 Jens Maus <mail@jens-maus.de>"
+msg "Copyright (c) 2022-2026 Jens Maus <mail@jens-maus.de>"
 msg ""
 
 # check if this is a Proxmox system and if so
@@ -409,7 +409,7 @@ fi
 
 if docker container inspect "${CCU_CONTAINER_NAME}" >/dev/null 2>&1; then
   msg "Removing old container (not user data)"
-  docker stop --time 120 "${CCU_CONTAINER_NAME}" >/dev/null || true
+  docker stop --timeout 120 "${CCU_CONTAINER_NAME}" >/dev/null || true
   docker rm "${CCU_CONTAINER_NAME}" >/dev/null || true
 fi
 
@@ -505,7 +505,7 @@ if ${DOCKER_COMMAND} >/dev/null; then
   msg  "- Start container with \"docker start ccu\""
   msg  "- See logs with \"docker logs ${CCU_CONTAINER_NAME}\""
   msg  "- Connect to http://${CCU_CONTAINER_IP}/"
-  msg  "- Stop container with \"docker stop --time 120 ccu\""
+  msg  "- Stop container with \"docker stop --timeout 120 ccu\""
   msg  "- Uninstall container environment with \"${0} uninstall\""
   exit 0
 else

--- a/scripts/patch-ha-addon-macvlan.sh
+++ b/scripts/patch-ha-addon-macvlan.sh
@@ -17,7 +17,7 @@
 #
 # CCU_CONTAINER_IP=192.168.178.30 ./patch-ha-addon-macvlan.sh -n
 #
-# Copyright (c) 2023-2024 Jens Maus <mail@jens-maus.de>
+# Copyright (c) 2023-2026 Jens Maus <mail@jens-maus.de>
 # Apache 2.0 License applies
 #
 
@@ -43,8 +43,8 @@
 #############################################################
 #                         Main App                          #
 #############################################################
-echo "OpenCCU HA-Addon macvlan patch script v1.2"
-echo "Copyright (c) 2023-2024 Jens Maus <mail@jens-maus.de>"
+echo "OpenCCU HA-Addon macvlan patch script v1.3"
+echo "Copyright (c) 2023-2026 Jens Maus <mail@jens-maus.de>"
 echo
 
 # check if non-interactive mode is requested
@@ -182,7 +182,7 @@ echo "Connecting add-on to macvlan network"
 docker network connect --ip "${CCU_CONTAINER_IP}" ccu "${CCU_CONTAINER_NAME}"
 
 echo "Stopping add-on (${CCU_CONTAINER_NAME})"
-docker stop --time 120 "${CCU_CONTAINER_NAME}"
+docker stop --timeout 120 "${CCU_CONTAINER_NAME}"
 
 echo "Starting add-on (${CCU_CONTAINER_NAME})"
 docker start "${CCU_CONTAINER_NAME}"


### PR DESCRIPTION
This change uses the --timeout command-line option rather than the old/obsolete --time option which may cause warnings to be emitted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker installation script to version 1.17 and patching script to version 1.3.
  * Corrected Docker stop command parameter syntax in both scripts.
  * Updated copyright year information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenCCU/OpenCCU/pull/3868?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->