### PR TITLE
bump rpi-eeprom to c5ea2eb

### DIFF
--- a/buildroot-external/package/rpi-eeprom/rpi-eeprom.hash
+++ b/buildroot-external/package/rpi-eeprom/rpi-eeprom.hash
@@ -1,3 +1,3 @@
 # Locally computed
 sha256  594b7565fd3ccf8acd4711a2ec1b199181aafbc3426d0bacaa50ef40edbf7c4a  LICENSE
-sha256  3c5979fd33d2804fd3556f497845ea8b1231d27d906549f7e225703ff73d09d0  rpi-eeprom-bf19070528db9ce435d4fbdcdc626807c38e6d3d.tar.gz
+sha256  f085c7fbd6eecd0fe0e37fa023599070a13124cea8a1fb24d3904c5a77b35cef  rpi-eeprom-c5ea2eb4dc4de9700d4102cbb5517efb3c1eced6.tar.gz

--- a/buildroot-external/package/rpi-eeprom/rpi-eeprom.mk
+++ b/buildroot-external/package/rpi-eeprom/rpi-eeprom.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-RPI_EEPROM_VERSION = bf19070528db9ce435d4fbdcdc626807c38e6d3d
+RPI_EEPROM_VERSION = c5ea2eb4dc4de9700d4102cbb5517efb3c1eced6
 RPI_EEPROM_SITE = $(call github,raspberrypi,rpi-eeprom,$(RPI_EEPROM_VERSION))
 RPI_EEPROM_LICENSE = BSD-3-Clause, MIT, uIP, custom
 RPI_EEPROM_LICENSE_FILES = LICENSE


### PR DESCRIPTION
Dependency update generated by nightly update check workflow.

Updated component:
- Name...: `rpi-eeprom`
- Package: `rpi-eeprom`
- Current version: `bf19070`
- New version....: `c5ea2eb`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated RPi EEPROM firmware package to a newer upstream version with corresponding checksum update.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenCCU/OpenCCU/pull/3887?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->