### PR TITLE
bump tailscale to 1.98.3

### DIFF
--- a/buildroot-external/package/tailscale-bin/tailscale-bin.hash
+++ b/buildroot-external/package/tailscale-bin/tailscale-bin.hash
@@ -1,4 +1,4 @@
 # Locally computed
 sha256  a7ca6186a7963a0a60740f6047760eecd7a0234e8c38bd7e1e0bbcb324bda45b  LICENSE
-sha256  aae02be635e8bffbdaecefb3518344357d39d904c1bbe1e7ca95cd0cbb8ad21c  tailscale_1.98.2_amd64.tgz
-sha256  6f56441fedd4309fb949e8f257d7bd93bc157191968918b906a781fc25029ad4  tailscale_1.98.2_arm64.tgz
+sha256  a53002b0052317179d3fcace99dcd94c87b634dbb453da06b7374a4420c8160a  tailscale_1.98.3_amd64.tgz
+sha256  d26ce4a1a259621fc76d16c7baf3f3a4252f356dfa9d9769484782f766ca1b7f  tailscale_1.98.3_arm64.tgz

--- a/buildroot-external/package/tailscale-bin/tailscale-bin.mk
+++ b/buildroot-external/package/tailscale-bin/tailscale-bin.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-TAILSCALE_BIN_VERSION = 1.98.2
+TAILSCALE_BIN_VERSION = 1.98.3
 TAILSCALE_BIN_SITE = https://pkgs.tailscale.com/stable
 ifeq ($(call qstrip,$(BR2_ARCH)),aarch64)
 TAILSCALE_BIN_SOURCE = tailscale_$(TAILSCALE_BIN_VERSION)_arm64.tgz


### PR DESCRIPTION
Dependency update generated by nightly update check workflow.

Updated component:
- Name...: `tailscale`
- Package: `tailscale-bin`
- Current version: `1.98.2`
- New version....: `1.98.3`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Tailscale binary package to version 1.98.3.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenCCU/OpenCCU/pull/3893?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->