### PR TITLE
bump rpi-eeprom to 9c7eb94

### DIFF
--- a/buildroot-external/package/rpi-eeprom/rpi-eeprom.hash
+++ b/buildroot-external/package/rpi-eeprom/rpi-eeprom.hash
@@ -1,3 +1,3 @@
 # Locally computed
 sha256  594b7565fd3ccf8acd4711a2ec1b199181aafbc3426d0bacaa50ef40edbf7c4a  LICENSE
-sha256  68014da39215cc6111aff9fa3be3f14750d4d2073e9e86557b319a11ff2d34fb  rpi-eeprom-25f837ab8009a643ed85b9aad94d911baddaf0c4.tar.gz
+sha256  7ec41ab95b6091d2cf85cdfcf3b43dffe26e885a8e7cdfbffb41ab70f7736dbd  rpi-eeprom-9c7eb94e64b4d99c4f549a9f4c2479cb57400707.tar.gz

--- a/buildroot-external/package/rpi-eeprom/rpi-eeprom.mk
+++ b/buildroot-external/package/rpi-eeprom/rpi-eeprom.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-RPI_EEPROM_VERSION = 25f837ab8009a643ed85b9aad94d911baddaf0c4
+RPI_EEPROM_VERSION = 9c7eb94e64b4d99c4f549a9f4c2479cb57400707
 RPI_EEPROM_SITE = $(call github,raspberrypi,rpi-eeprom,$(RPI_EEPROM_VERSION))
 RPI_EEPROM_LICENSE = BSD-3-Clause, MIT, uIP, custom
 RPI_EEPROM_LICENSE_FILES = LICENSE
@@ -17,7 +17,7 @@ ifeq ($(BR2_PACKAGE_RPI_EEPROM_RPI4),y)
   RPI_EEPROM_VL805_GLOB = firmware-2711/stable/vl805-*.bin
 else ifeq ($(BR2_PACKAGE_RPI_EEPROM_RPI5),y)
   # Raspberry Pi 5 (2712)
-  RPI_EEPROM_FIRMWARE_PATH = firmware-2712/stable/pieeprom-2026-05-17.bin
+  RPI_EEPROM_FIRMWARE_PATH = firmware-2712/stable/pieeprom-2026-05-22.bin
   RPI_EEPROM_RECOVERY_PATH = firmware-2712/stable/recovery.bin
 endif
 


### PR DESCRIPTION
Dependency update generated by nightly update check workflow.

Updated component:
- Name...: `rpi-eeprom`
- Package: `rpi-eeprom`
- Current version: `25f837a`
- New version....: `9c7eb94`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Raspberry Pi EEPROM bootloader to a newer upstream version
  * Updated Raspberry Pi 5 bootloader firmware to a more recent build

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenCCU/OpenCCU/pull/3901?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->