### PR TITLE
modified S08argononed - prefers a user-configurable argononed_override.sh over the build-in argononed.sh

### DIFF
--- a/buildroot-external/package/argononed/S08argononed
+++ b/buildroot-external/package/argononed/S08argononed
@@ -9,17 +9,7 @@ PATH=/sbin:/bin:/usr/sbin:/usr/bin
 DAEMON="argononed"
 PIDFILE="/var/run/${DAEMON}.pid"
 
-# Path detection: Give priority to /usr/local/etc/config/argononed_override.sh, if it exists
-if [ -x "/usr/local/etc/config/argononed_override.sh" ]; then
-if [ -x "/usr/local/etc/config/argononed_override.sh" ]; then
-	DAEMON_PATH="/usr/local/etc/config/argononed_override.sh"
-else
-	DAEMON_PATH="/opt/argononed/${DAEMON}.sh"
-fi
-fi
-
-# Exit if daemon script is not executable
-test -x "${DAEMON_PATH}" || exit 0
+test -x "/opt/argononed/${DAEMON}.sh" || exit 0
 
 # source all data from /var/hm_mode
 [[ -r /var/hm_mode ]] && . /var/hm_mode
@@ -32,7 +22,7 @@ case $1 in
 		# Both seem to listen at 0x1a i2c address
 		if i2cget -y 1 0x1a 2>/dev/null >/dev/null; then
 
-			if start-stop-daemon -S -q -b -m -p "${PIDFILE}" --exec "${DAEMON_PATH}" 2>/dev/null >/dev/null; then
+			if start-stop-daemon -S -q -b -m -p "${PIDFILE}" --exec "/opt/argononed/${DAEMON}.sh" 2>/dev/null >/dev/null; then
 				echo "OK"
 			else
 				echo "FAIL"
@@ -64,7 +54,7 @@ case $1 in
 	;;
 
 	status)
-		"${DAEMON_PATH}" --status
+		/opt/argononed/${DAEMON}.sh --status
 	;;
 
 	*)

--- a/buildroot-external/package/argononed/S08argononed
+++ b/buildroot-external/package/argononed/S08argononed
@@ -9,7 +9,15 @@ PATH=/sbin:/bin:/usr/sbin:/usr/bin
 DAEMON="argononed"
 PIDFILE="/var/run/${DAEMON}.pid"
 
-test -x "/opt/argononed/${DAEMON}.sh" || exit 0
+# Path detection: Give priority to /usr/local/etc/config/argononed_override.sh, if it exists
+if [ -x "/usr/local/etc/config/argononed_override.sh" ]; then
+    DAEMON_PATH="/usr/local/etc/config/argononed_override.sh"
+else
+    DAEMON_PATH="/opt/argononed/${DAEMON}.sh"
+fi
+
+# Exit if daemon script is not executable
+test -x "${DAEMON_PATH}" || exit 0
 
 # source all data from /var/hm_mode
 [[ -r /var/hm_mode ]] && . /var/hm_mode
@@ -22,7 +30,7 @@ case $1 in
 		# Both seem to listen at 0x1a i2c address
 		if i2cget -y 1 0x1a 2>/dev/null >/dev/null; then
 
-			if start-stop-daemon -S -q -b -m -p "${PIDFILE}" --exec "/opt/argononed/${DAEMON}.sh" 2>/dev/null >/dev/null; then
+			if start-stop-daemon -S -q -b -m -p "${PIDFILE}" --exec "${DAEMON_PATH}" 2>/dev/null >/dev/null; then
 				echo "OK"
 			else
 				echo "FAIL"
@@ -54,7 +62,7 @@ case $1 in
 	;;
 
 	status)
-		/opt/argononed/${DAEMON}.sh --status
+		"${DAEMON_PATH}" --status
 	;;
 
 	*)

--- a/buildroot-external/package/argononed/S08argononed
+++ b/buildroot-external/package/argononed/S08argononed
@@ -11,9 +11,11 @@ PIDFILE="/var/run/${DAEMON}.pid"
 
 # Path detection: Give priority to /usr/local/etc/config/argononed_override.sh, if it exists
 if [ -x "/usr/local/etc/config/argononed_override.sh" ]; then
-    DAEMON_PATH="/usr/local/etc/config/argononed_override.sh"
+if [ -x "/usr/local/etc/config/argononed_override.sh" ]; then
+	DAEMON_PATH="/usr/local/etc/config/argononed_override.sh"
 else
-    DAEMON_PATH="/opt/argononed/${DAEMON}.sh"
+	DAEMON_PATH="/opt/argononed/${DAEMON}.sh"
+fi
 fi
 
 # Exit if daemon script is not executable

--- a/buildroot-external/package/argononed/rootfs-overlay/opt/argononed/argononed.sh
+++ b/buildroot-external/package/argononed/rootfs-overlay/opt/argononed/argononed.sh
@@ -78,22 +78,43 @@ fancontrol()
     esac
   }
 
+  validate_curve()
+  {
+    local prev_temp temp hyst level
+
+    prev_temp=-1
+    for level in 0 1 2 3 4; do
+      temp=$(level_temp "${level}")
+      hyst=$(level_hyst "${level}")
+
+      if [[ ${temp} -le ${prev_temp} ]] || [[ ${hyst} -gt ${temp} ]]; then
+        return 1
+      fi
+      prev_temp=${temp}
+    done
+  }
+
+  set_default_curve()
+  {
+    fan_temp0=56000
+    fan_temp0_speed=10
+    fan_temp0_hyst=2000
+    fan_temp1=66000
+    fan_temp1_speed=15
+    fan_temp1_hyst=2000
+    fan_temp2=70000
+    fan_temp2_speed=26
+    fan_temp2_hyst=2000
+    fan_temp3=75000
+    fan_temp3_speed=128
+    fan_temp3_hyst=2000
+    fan_temp4=80000
+    fan_temp4_speed=255
+    fan_temp4_hyst=2000
+  }
+
   # default fan curve, can be overwritten in /etc/config/argoned.conf
-  fan_temp0=56000
-  fan_temp0_speed=10
-  fan_temp0_hyst=2000
-  fan_temp1=66000
-  fan_temp1_speed=15
-  fan_temp1_hyst=2000
-  fan_temp2=70000
-  fan_temp2_speed=26
-  fan_temp2_hyst=2000
-  fan_temp3=75000
-  fan_temp3_speed=128
-  fan_temp3_hyst=2000
-  fan_temp4=80000
-  fan_temp4_speed=255
-  fan_temp4_hyst=2000
+  set_default_curve
 
   # shellcheck disable=SC1091
   [[ -r /etc/config/argoned.conf ]] && . /etc/config/argoned.conf
@@ -119,6 +140,16 @@ fancontrol()
   fan_temp2_speed_percent=$(speed255_to_percent "${fan_temp2_speed}")
   fan_temp3_speed_percent=$(speed255_to_percent "${fan_temp3_speed}")
   fan_temp4_speed_percent=$(speed255_to_percent "${fan_temp4_speed}")
+
+  if ! validate_curve; then
+    logger -t argononed "Invalid fan curve in /etc/config/argoned.conf, falling back to defaults"
+    set_default_curve
+    fan_temp0_speed_percent=$(speed255_to_percent "${fan_temp0_speed}")
+    fan_temp1_speed_percent=$(speed255_to_percent "${fan_temp1_speed}")
+    fan_temp2_speed_percent=$(speed255_to_percent "${fan_temp2_speed}")
+    fan_temp3_speed_percent=$(speed255_to_percent "${fan_temp3_speed}")
+    fan_temp4_speed_percent=$(speed255_to_percent "${fan_temp4_speed}")
+  fi
 
   while true; do
     curtemp=$(sanitize_uint "$(cat /sys/class/thermal/thermal_zone0/temp 2>/dev/null || echo 0)" "0")

--- a/buildroot-external/package/argononed/rootfs-overlay/opt/argononed/argononed.sh
+++ b/buildroot-external/package/argononed/rootfs-overlay/opt/argononed/argononed.sh
@@ -113,11 +113,11 @@ fancontrol()
     fan_temp4_hyst=2000
   }
 
-  # default fan curve, can be overwritten in /etc/config/argoned.conf
+  # default fan curve, can be overwritten in /etc/config/argononed.conf
   set_default_curve
 
   # shellcheck disable=SC1091
-  [[ -r /etc/config/argoned.conf ]] && . /etc/config/argoned.conf
+  [[ -r /etc/config/argononed.conf ]] && . /etc/config/argononed.conf
 
   fan_temp0=$(sanitize_uint "${fan_temp0}" "56000")
   fan_temp1=$(sanitize_uint "${fan_temp1}" "66000")
@@ -142,7 +142,7 @@ fancontrol()
   fan_temp4_speed_percent=$(speed255_to_percent "${fan_temp4_speed}")
 
   if ! validate_curve; then
-    logger -t argononed "Invalid fan curve in /etc/config/argoned.conf, falling back to defaults"
+    logger -t argononed "Invalid fan curve in /etc/config/argononed.conf, falling back to defaults"
     set_default_curve
     fan_temp0_speed_percent=$(speed255_to_percent "${fan_temp0_speed}")
     fan_temp1_speed_percent=$(speed255_to_percent "${fan_temp1_speed}")

--- a/buildroot-external/package/argononed/rootfs-overlay/opt/argononed/argononed.sh
+++ b/buildroot-external/package/argononed/rootfs-overlay/opt/argononed/argononed.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# shellcheck shell=dash disable=SC2169
+# shellcheck shell=dash disable=SC2169,SC3010
 #
 # A shell script variant of a control daemon to
 # control the fan and power buttons of a ArgonONE case
@@ -12,25 +12,146 @@ fancontrol()
 {
   curspeed=-1
   dstspeed=0
+  current_level=-1
+
+  speed255_to_percent()
+  {
+    local speed255
+
+    speed255=$1
+    if [[ ${speed255} -lt 0 ]]; then
+      speed255=0
+    elif [[ ${speed255} -gt 255 ]]; then
+      speed255=255
+    fi
+    echo $(( (speed255 * 100 + 127) / 255 ))
+  }
+
+  sanitize_uint()
+  {
+    local value fallback
+
+    value=$1
+    fallback=$2
+    case "${value}" in
+      ''|*[!0-9]*)
+        echo "${fallback}"
+        ;;
+      *)
+        echo "${value}"
+        ;;
+    esac
+  }
+
+  level_temp()
+  {
+    case "$1" in
+      0) echo "${fan_temp0}" ;;
+      1) echo "${fan_temp1}" ;;
+      2) echo "${fan_temp2}" ;;
+      3) echo "${fan_temp3}" ;;
+      4) echo "${fan_temp4}" ;;
+    esac
+  }
+
+  level_hyst()
+  {
+    case "$1" in
+      0) echo "${fan_temp0_hyst}" ;;
+      1) echo "${fan_temp1_hyst}" ;;
+      2) echo "${fan_temp2_hyst}" ;;
+      3) echo "${fan_temp3_hyst}" ;;
+      4) echo "${fan_temp4_hyst}" ;;
+      *) echo "0" ;;
+    esac
+  }
+
+  level_speed_percent()
+  {
+    case "$1" in
+      0) echo "${fan_temp0_speed_percent}" ;;
+      1) echo "${fan_temp1_speed_percent}" ;;
+      2) echo "${fan_temp2_speed_percent}" ;;
+      3) echo "${fan_temp3_speed_percent}" ;;
+      4) echo "${fan_temp4_speed_percent}" ;;
+      *) echo "0" ;;
+    esac
+  }
+
+  # default fan curve, can be overwritten in /etc/config/argoned.conf
+  fan_temp0=56000
+  fan_temp0_speed=10
+  fan_temp0_hyst=2000
+  fan_temp1=66000
+  fan_temp1_speed=15
+  fan_temp1_hyst=2000
+  fan_temp2=70000
+  fan_temp2_speed=26
+  fan_temp2_hyst=2000
+  fan_temp3=75000
+  fan_temp3_speed=128
+  fan_temp3_hyst=2000
+  fan_temp4=80000
+  fan_temp4_speed=255
+  fan_temp4_hyst=2000
+
+  # shellcheck disable=SC1091
+  [[ -r /etc/config/argoned.conf ]] && . /etc/config/argoned.conf
+
+  fan_temp0=$(sanitize_uint "${fan_temp0}" "56000")
+  fan_temp1=$(sanitize_uint "${fan_temp1}" "66000")
+  fan_temp2=$(sanitize_uint "${fan_temp2}" "70000")
+  fan_temp3=$(sanitize_uint "${fan_temp3}" "75000")
+  fan_temp4=$(sanitize_uint "${fan_temp4}" "80000")
+  fan_temp0_hyst=$(sanitize_uint "${fan_temp0_hyst}" "2000")
+  fan_temp1_hyst=$(sanitize_uint "${fan_temp1_hyst}" "2000")
+  fan_temp2_hyst=$(sanitize_uint "${fan_temp2_hyst}" "2000")
+  fan_temp3_hyst=$(sanitize_uint "${fan_temp3_hyst}" "2000")
+  fan_temp4_hyst=$(sanitize_uint "${fan_temp4_hyst}" "2000")
+  fan_temp0_speed=$(sanitize_uint "${fan_temp0_speed}" "10")
+  fan_temp1_speed=$(sanitize_uint "${fan_temp1_speed}" "15")
+  fan_temp2_speed=$(sanitize_uint "${fan_temp2_speed}" "26")
+  fan_temp3_speed=$(sanitize_uint "${fan_temp3_speed}" "128")
+  fan_temp4_speed=$(sanitize_uint "${fan_temp4_speed}" "255")
+
+  fan_temp0_speed_percent=$(speed255_to_percent "${fan_temp0_speed}")
+  fan_temp1_speed_percent=$(speed255_to_percent "${fan_temp1_speed}")
+  fan_temp2_speed_percent=$(speed255_to_percent "${fan_temp2_speed}")
+  fan_temp3_speed_percent=$(speed255_to_percent "${fan_temp3_speed}")
+  fan_temp4_speed_percent=$(speed255_to_percent "${fan_temp4_speed}")
 
   while true; do
-    curtemp=$( (cat /sys/class/thermal/thermal_zone0/temp 2>/dev/null || echo 0) | awk '{printf "%.0f\n", $1/1000}' )
-    if [[ ${curtemp} -ge 80 ]]; then
-      dstspeed=100
-    elif [[ ${curtemp} -ge 75 ]]; then
-      dstspeed=50
-    elif [[ ${curtemp} -ge 70 ]]; then
-      dstspeed=10
-    elif [[ ${curtemp} -ge 65 ]]; then
-      dstspeed=5
-    elif [[ ${curtemp} -ge 55 ]]; then
-      dstspeed=3
+    curtemp=$(sanitize_uint "$(cat /sys/class/thermal/thermal_zone0/temp 2>/dev/null || echo 0)" "0")
+
+    next_level=$(( current_level + 1 ))
+    while [[ ${next_level} -le 4 ]]; do
+      next_temp=$(level_temp "${next_level}")
+      if [[ ${curtemp} -ge ${next_temp} ]]; then
+        current_level=${next_level}
+        next_level=$(( next_level + 1 ))
+      else
+        break
+      fi
+    done
+
+    while [[ ${current_level} -ge 0 ]]; do
+      level_temp_value=$(level_temp "${current_level}")
+      level_hyst_value=$(level_hyst "${current_level}")
+      if [[ ${curtemp} -lt $(( level_temp_value - level_hyst_value )) ]]; then
+        current_level=$(( current_level - 1 ))
+      else
+        break
+      fi
+    done
+
+    if [[ ${current_level} -ge 0 ]]; then
+      dstspeed=$(level_speed_percent "${current_level}")
     else
       dstspeed=0
     fi
 
     if [[ ${dstspeed} -ne ${curspeed} ]]; then
-      /usr/sbin/i2cset -y 1 0x1a ${dstspeed}
+      /usr/sbin/i2cset -y 1 0x1a "${dstspeed}"
       curspeed=${dstspeed}
     fi
 


### PR DESCRIPTION
If available, use /usr/local/etc/config/argononed_override.sh instead of /opt/argononed/argononed.sh.

The user must copy the build-in `/opt/argononed/argononed.sh` to `/usr/local/etc/config/argononed_override.sh` and can modify the parameters.
Using `/etc/init.d/S08argononed restart` afterwards to use the own "fan-curve".

I'll add the documentation to the wiki once this is implemented.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-level configurable fan curve with per-level hysteresis for smoother thermal control
  * Optional configuration file support to customize levels, temperatures, hysteresis and speeds
  * Input sanitization and automatic conversion of configured speeds to controller percentages

* **Bug Fixes / Reliability**
  * Validation of configured curves with fallback to safe defaults and logged warnings on invalid input
  * Reduces unnecessary fan updates by only applying speed changes when needed

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenCCU/OpenCCU/pull/3923?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->