### PR TITLE
bump rpi-eeprom to d3a7a93

### DIFF
--- a/buildroot-external/package/rpi-eeprom/rpi-eeprom.hash
+++ b/buildroot-external/package/rpi-eeprom/rpi-eeprom.hash
@@ -1,3 +1,3 @@
 # Locally computed
 sha256  594b7565fd3ccf8acd4711a2ec1b199181aafbc3426d0bacaa50ef40edbf7c4a  LICENSE
-sha256  e4b1cbc6c72bfbc7e3edf56df3bb4c2061eaf93981c49ac94365103f9d1de6be  rpi-eeprom-05d94be4554ce44a057bfce8d0dd37d951703dab.tar.gz
+sha256  4ca5333ce46f23f2b16d5f5bc8174fd9a1dc588880aed21d978fa971f1929553  rpi-eeprom-d3a7a93316ae19f6045607d8fdcd9b86020354d7.tar.gz

--- a/buildroot-external/package/rpi-eeprom/rpi-eeprom.mk
+++ b/buildroot-external/package/rpi-eeprom/rpi-eeprom.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-RPI_EEPROM_VERSION = 05d94be4554ce44a057bfce8d0dd37d951703dab
+RPI_EEPROM_VERSION = d3a7a93316ae19f6045607d8fdcd9b86020354d7
 RPI_EEPROM_SITE = $(call github,raspberrypi,rpi-eeprom,$(RPI_EEPROM_VERSION))
 RPI_EEPROM_LICENSE = BSD-3-Clause, MIT, uIP, custom
 RPI_EEPROM_LICENSE_FILES = LICENSE


### PR DESCRIPTION
Dependency update generated by nightly update check workflow.

Updated component:
- Name...: `rpi-eeprom`
- Package: `rpi-eeprom`
- Current version: `05d94be`
- New version....: `d3a7a93`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Raspberry Pi EEPROM firmware package to a newer version with corresponding checksum verification updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->