### PR TITLE
bump rpi-eeprom to 114e49b

### DIFF
--- a/buildroot-external/package/rpi-eeprom/rpi-eeprom.hash
+++ b/buildroot-external/package/rpi-eeprom/rpi-eeprom.hash
@@ -1,3 +1,3 @@
 # Locally computed
 sha256  594b7565fd3ccf8acd4711a2ec1b199181aafbc3426d0bacaa50ef40edbf7c4a  LICENSE
-sha256  8ff7ba15aa5c43efdfb682bdaa265d8eaa3b06d1cce59e5494617c8363efdf27  rpi-eeprom-30b7e2363ad05169f5d7d96542e9d89dba3eaad7.tar.gz
+sha256  2e863c066e0a4f4398926595c51c2ebe1822234146bd3dcbe03d96ff6773918a  rpi-eeprom-114e49b9088cda026b35e5d44f7248ddedc309b2.tar.gz

--- a/buildroot-external/package/rpi-eeprom/rpi-eeprom.mk
+++ b/buildroot-external/package/rpi-eeprom/rpi-eeprom.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-RPI_EEPROM_VERSION = 30b7e2363ad05169f5d7d96542e9d89dba3eaad7
+RPI_EEPROM_VERSION = 114e49b9088cda026b35e5d44f7248ddedc309b2
 RPI_EEPROM_SITE = $(call github,raspberrypi,rpi-eeprom,$(RPI_EEPROM_VERSION))
 RPI_EEPROM_LICENSE = BSD-3-Clause, MIT, uIP, custom
 RPI_EEPROM_LICENSE_FILES = LICENSE


### PR DESCRIPTION
Dependency update generated by nightly update check workflow.

Updated component:
- Name...: `rpi-eeprom`
- Package: `rpi-eeprom`
- Current version: `30b7e23`
- New version....: `114e49b`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated rpi-eeprom firmware to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->