### PR TITLE
fix missing partuuid 0xdeedbeef force in resize userfs operation in fwinstall.sh

### DIFF
--- a/buildroot-external/package/recovery-system/external/overlay/base/bin/fwinstall.sh
+++ b/buildroot-external/package/recovery-system/external/overlay/base/bin/fwinstall.sh
@@ -113,6 +113,11 @@ expand_userfs_to_max()
     mount -o rw /userfs 2>/dev/null || true
     return 2
   fi
+
+  # force PARTUUID to 0xDEEDBEEF because parted changes partuuid
+  echo -en '\xEF\xBE\xED\xDE' | /bin/dd of="${DISK_DEV}" conv=notrunc bs=1 seek=$((0x1B8)) 2>/dev/null
+
+  # use partprobe to query for updated parttable
   partprobe "${DISK_DEV}" 2>/dev/null || true
 
   /sbin/e2fsck -pDf "${USER_DEV}" >/dev/null 2>&1


### PR DESCRIPTION
This PR fixes the fwinstall.sh userfs resize operation by adding a missing partuuid force operation ensuring the disk label 0xdeedbeef.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved partition handling in the recovery system during firmware installation to ensure proper partition identification and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->