### PR TITLE
bump rpi-eeprom to 930225c

### DIFF
--- a/buildroot-external/package/rpi-eeprom/rpi-eeprom.hash
+++ b/buildroot-external/package/rpi-eeprom/rpi-eeprom.hash
@@ -1,3 +1,3 @@
 # Locally computed
 sha256  594b7565fd3ccf8acd4711a2ec1b199181aafbc3426d0bacaa50ef40edbf7c4a  LICENSE
-sha256  2e863c066e0a4f4398926595c51c2ebe1822234146bd3dcbe03d96ff6773918a  rpi-eeprom-114e49b9088cda026b35e5d44f7248ddedc309b2.tar.gz
+sha256  bfe8a8162246bcde4e3a5d2d2e77be1c1e80621d4c287abe9a08bbe7d3ac95f8  rpi-eeprom-930225cc81612e83bd5f81ccbfb9de58d689bb0e.tar.gz

--- a/buildroot-external/package/rpi-eeprom/rpi-eeprom.mk
+++ b/buildroot-external/package/rpi-eeprom/rpi-eeprom.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-RPI_EEPROM_VERSION = 114e49b9088cda026b35e5d44f7248ddedc309b2
+RPI_EEPROM_VERSION = 930225cc81612e83bd5f81ccbfb9de58d689bb0e
 RPI_EEPROM_SITE = $(call github,raspberrypi,rpi-eeprom,$(RPI_EEPROM_VERSION))
 RPI_EEPROM_LICENSE = BSD-3-Clause, MIT, uIP, custom
 RPI_EEPROM_LICENSE_FILES = LICENSE


### PR DESCRIPTION
Dependency update generated by nightly update check workflow.

Updated component:
- Name...: `rpi-eeprom`
- Package: `rpi-eeprom`
- Current version: `114e49b`
- New version....: `930225c`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated rpi-eeprom package to the latest version with new checksums and build configuration updates to ensure proper firmware installation and system integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->