### PR TITLE
bump rpi-eeprom to 8cf437f

### DIFF
--- a/buildroot-external/package/rpi-eeprom/rpi-eeprom.hash
+++ b/buildroot-external/package/rpi-eeprom/rpi-eeprom.hash
@@ -1,3 +1,3 @@
 # Locally computed
 sha256  594b7565fd3ccf8acd4711a2ec1b199181aafbc3426d0bacaa50ef40edbf7c4a  LICENSE
-sha256  bfe8a8162246bcde4e3a5d2d2e77be1c1e80621d4c287abe9a08bbe7d3ac95f8  rpi-eeprom-930225cc81612e83bd5f81ccbfb9de58d689bb0e.tar.gz
+sha256  11f379afee44eca0037adf29ab05974a59ab83928c6a5c815f4c09efa488350f  rpi-eeprom-8cf437f4c2c3f1fd7d950fe02f19c5a209d4ff1b.tar.gz

--- a/buildroot-external/package/rpi-eeprom/rpi-eeprom.mk
+++ b/buildroot-external/package/rpi-eeprom/rpi-eeprom.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-RPI_EEPROM_VERSION = 930225cc81612e83bd5f81ccbfb9de58d689bb0e
+RPI_EEPROM_VERSION = 8cf437f4c2c3f1fd7d950fe02f19c5a209d4ff1b
 RPI_EEPROM_SITE = $(call github,raspberrypi,rpi-eeprom,$(RPI_EEPROM_VERSION))
 RPI_EEPROM_LICENSE = BSD-3-Clause, MIT, uIP, custom
 RPI_EEPROM_LICENSE_FILES = LICENSE


### PR DESCRIPTION
Dependency update generated by nightly update check workflow.

Updated component:
- Name...: `rpi-eeprom`
- Package: `rpi-eeprom`
- Current version: `930225c`
- New version....: `8cf437f`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Raspberry Pi EEPROM package to a newer version with the latest firmware support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->