### PR TITLE
bump rpi-eeprom to 77c27a9

### DIFF
--- a/buildroot-external/package/rpi-eeprom/rpi-eeprom.hash
+++ b/buildroot-external/package/rpi-eeprom/rpi-eeprom.hash
@@ -1,3 +1,3 @@
 # Locally computed
 sha256  594b7565fd3ccf8acd4711a2ec1b199181aafbc3426d0bacaa50ef40edbf7c4a  LICENSE
-sha256  11f379afee44eca0037adf29ab05974a59ab83928c6a5c815f4c09efa488350f  rpi-eeprom-8cf437f4c2c3f1fd7d950fe02f19c5a209d4ff1b.tar.gz
+sha256  2fb21eaca427731d9453d75a6448ddcf9245ee62dc850a613703d2eec5aa69d9  rpi-eeprom-77c27a9be723c3339d93d03c3a90a148eb40129e.tar.gz

--- a/buildroot-external/package/rpi-eeprom/rpi-eeprom.mk
+++ b/buildroot-external/package/rpi-eeprom/rpi-eeprom.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-RPI_EEPROM_VERSION = 8cf437f4c2c3f1fd7d950fe02f19c5a209d4ff1b
+RPI_EEPROM_VERSION = 77c27a9be723c3339d93d03c3a90a148eb40129e
 RPI_EEPROM_SITE = $(call github,raspberrypi,rpi-eeprom,$(RPI_EEPROM_VERSION))
 RPI_EEPROM_LICENSE = BSD-3-Clause, MIT, uIP, custom
 RPI_EEPROM_LICENSE_FILES = LICENSE


### PR DESCRIPTION
Dependency update generated by nightly update check workflow.

Updated component:
- Name...: `rpi-eeprom`
- Package: `rpi-eeprom`
- Current version: `8cf437f`
- New version....: `77c27a9`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Raspberry Pi EEPROM firmware package to a newer version with corresponding checksum validation updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->