### PR TITLE
add python3-requests dependency in install-proxmox.sh

### DIFF
--- a/scripts/install-proxmox.sh
+++ b/scripts/install-proxmox.sh
@@ -24,7 +24,7 @@ trap die ERR
 trap cleanup EXIT
 
 # Set default variables
-VERSION="3.21"
+VERSION="3.22"
 LOGFILE="/tmp/install-proxmox.log"
 LINE=
 
@@ -513,6 +513,9 @@ EOF
   fi
   if ! pkg_installed gpg; then
     apt install -y gpg
+  fi
+  if ! pkg_installed python3-requests; then
+    apt install -y python3-requests
   fi
 
   # use gpg to dearmor the pivccu public key

--- a/scripts/install-proxmox.sh
+++ b/scripts/install-proxmox.sh
@@ -442,6 +442,16 @@ fi
 # check that this script is run as root/sudo
 check_sudo
 
+info "Checking/Installing host package dependencies..."
+
+# check that all necessary host packages are installed
+if ! pkg_installed wget; then
+  apt install -y wget
+fi
+if ! pkg_installed python3-requests; then
+  apt install -y python3-requests
+fi
+
 # PVE platform
 PLATFORM=$(uname -m)
 
@@ -493,9 +503,6 @@ EOF
   info "Checking/Installing host package dependencies..."
 
   # check that all necessary host packages are installed
-  if ! pkg_installed wget; then
-    apt install -y wget
-  fi
   if ! pkg_installed ca-certificates; then
     apt install -y ca-certificates
   fi
@@ -513,9 +520,6 @@ EOF
   fi
   if ! pkg_installed gpg; then
     apt install -y gpg
-  fi
-  if ! pkg_installed python3-requests; then
-    apt install -y python3-requests
   fi
 
   # use gpg to dearmor the pivccu public key


### PR DESCRIPTION
This adds python3-requests as a required dependency apt package to the install-proxmox.sh script because in some ProxmoxVE constellations this package might be missing to correctly download all necessary information.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Proxmox installation to target OpenCCU version 3.22
  * Ensured required host packages are installed during setup, including `python3-requests` (and `wget` when missing)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->