### PR TITLE
bump rpi-eeprom to 6e2ec7a

### DIFF
--- a/buildroot-external/package/rpi-eeprom/rpi-eeprom.hash
+++ b/buildroot-external/package/rpi-eeprom/rpi-eeprom.hash
@@ -1,3 +1,3 @@
 # Locally computed
 sha256  594b7565fd3ccf8acd4711a2ec1b199181aafbc3426d0bacaa50ef40edbf7c4a  LICENSE
-sha256  14d454cfbf53516671f9be266141d770045948fc75036b05c67b08ddf6eb027e  rpi-eeprom-8fb9ea2fcb1735616a72fe6c5eb15b96595fc35d.tar.gz
+sha256  d76f1374917bdd3c7388b0a64f8b0d34e401ae00b2b3420663778d1e652a0c4e  rpi-eeprom-6e2ec7a15dbe2ccb8ac4def872704af959eeb1c6.tar.gz

--- a/buildroot-external/package/rpi-eeprom/rpi-eeprom.mk
+++ b/buildroot-external/package/rpi-eeprom/rpi-eeprom.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-RPI_EEPROM_VERSION = 8fb9ea2fcb1735616a72fe6c5eb15b96595fc35d
+RPI_EEPROM_VERSION = 6e2ec7a15dbe2ccb8ac4def872704af959eeb1c6
 RPI_EEPROM_SITE = $(call github,raspberrypi,rpi-eeprom,$(RPI_EEPROM_VERSION))
 RPI_EEPROM_LICENSE = BSD-3-Clause, MIT, uIP, custom
 RPI_EEPROM_LICENSE_FILES = LICENSE
@@ -17,7 +17,7 @@ ifeq ($(BR2_PACKAGE_RPI_EEPROM_RPI4),y)
   RPI_EEPROM_VL805_GLOB = firmware-2711/stable/vl805-*.bin
 else ifeq ($(BR2_PACKAGE_RPI_EEPROM_RPI5),y)
   # Raspberry Pi 5 (2712)
-  RPI_EEPROM_FIRMWARE_PATH = firmware-2712/stable/pieeprom-2026-05-26.bin
+  RPI_EEPROM_FIRMWARE_PATH = firmware-2712/stable/pieeprom-2026-06-17.bin
   RPI_EEPROM_RECOVERY_PATH = firmware-2712/stable/recovery.bin
 endif
 


### PR DESCRIPTION
Dependency update generated by nightly update check workflow.

Updated component:
- Name...: `rpi-eeprom`
- Package: `rpi-eeprom`
- Current version: `8fb9ea2`
- New version....: `6e2ec7a`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated RPi EEPROM package to a newer version
  * Updated Raspberry Pi 5 firmware to the latest stable release

<!-- end of auto-generated comment: release notes by coderabbit.ai -->