### PR TITLE
recovery: do not source uploaded firmware_version in restore_backup.cgi (fixes #3962)

### DIFF
--- a/buildroot-external/package/recovery-system/external/package/hm-platform/rootfs-overlay/www/cgi-bin/restore_backup.cgi
+++ b/buildroot-external/package/recovery-system/external/package/hm-platform/rootfs-overlay/www/cgi-bin/restore_backup.cgi
@@ -1,5 +1,5 @@
 #!/bin/sh
-# shellcheck shell=dash disable=SC2169,SC2034 source=/dev/null
+# shellcheck shell=dash disable=SC2169,SC2034
 
 echo -ne "Content-Type: text/html; charset=iso-8859-1\r\n\r\n"
 
@@ -95,8 +95,16 @@ echo "OK<br>"
 
 # check the firmware version
 echo -ne "[4/8] Checking backup version... "
-source "${TMPDIR}/firmware_version"
-BACKUP_VERSION=${VERSION}
+# SECURITY: never 'source' the firmware_version file. It originates from the
+# uploaded archive which is still unverified at this point, so sourcing would
+# execute arbitrary shell code as root. Parse the VERSION value without
+# evaluating the file (the file format is a single "VERSION=..." line, see
+# createBackup.sh).
+if [ ! -f "${TMPDIR}/firmware_version" ]; then
+  echo "ERROR: backup is missing firmware_version"
+  exit 1
+fi
+BACKUP_VERSION=$(sed -n 's/^VERSION=//p' "${TMPDIR}/firmware_version" | head -n1 | tr -d '[:space:]')
 if [ "$(echo "${BACKUP_VERSION}" | cut -d'.' -f1)" != "2" ] && [ "$(echo "${BACKUP_VERSION}" | cut -d'.' -f1)" != "3" ]; then
   echo "ERROR: backup version (${BACKUP_VERSION}) not supported"
   exit 1


### PR DESCRIPTION
## What

Fixes the unauthenticated root RCE reported in #3962.

`restore_backup.cgi` extracted the uploaded backup archive and then ran `source "${TMPDIR}/firmware_version"` at step `[4/8]` to read the backup version. That file comes straight from the **untrusted, not-yet-verified** upload, so `source` executed arbitrary shell code **as root** before the signature check at step `[5/8]` ever ran. Combined with the recovery web UI having no authentication (`mod_auth` disabled), this allowed unauthenticated remote code execution as root on a device booted into the recovery system.

## Why reordering alone isn't enough

The backup signature (`crypttool`) only covers `usr_local.tar.gz`. `firmware_version` is **unsigned** metadata, so verifying the signature first would still leave an unauthenticated, attacker-controlled file being `source`d. The fix therefore stops evaluating the file entirely.

## Change

Parse the `VERSION` value without evaluating the file:

```sh
BACKUP_VERSION=$(sed -n 's/^VERSION=//p' "${TMPDIR}/firmware_version" | head -n1 | tr -d '[:space:]')
```

- The existing major-version (`2`/`3`) check is preserved unchanged.
- A missing-file guard is added.
- The now-obsolete `source=/dev/null` shellcheck directive is removed.

The file format is a single `VERSION=...` line (see `createBackup.sh`), so legitimate backups parse identically.

## Verification

Unit-tested the old vs. new snippet under `dash` across five inputs:

| Input | OLD (`source`) | NEW (`sed` parse) |
|------|----------------|-------------------|
| `VERSION=3.87.6.20260617` | parsed ✓ | ACCEPTED ✓ |
| `VERSION=2.57.7.20210327` | parsed ✓ | ACCEPTED ✓ |
| newline + `touch /tmp/PWNED` | **executed as root** | no execution — safe |
| `VERSION=3.0$(touch /tmp/PWNED)` | **executed as root** | no execution — safe |
| `VERSION=1.2.3` | n/a | correctly REJECTED |

Legitimate backups behave identically; both injection vectors are neutralized. Uses only POSIX/busybox tools (`sed`/`head`/`tr`/`cut`), matching the script's `shell=dash` target.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced backup restoration security by implementing safer file validation to prevent execution of potentially malicious content from untrusted backup archives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->