### PR TITLE
WebUI: escape systemName before ReGaScript interpolation in cp_advancedsettings.cgi (root RCE fix)

### DIFF
--- a/buildroot-external/patches/occu/0135-WebUI-Add-ControlPanel-AdvancedSettings.patch
+++ b/buildroot-external/patches/occu/0135-WebUI-Add-ControlPanel-AdvancedSettings.patch
@@ -49,7 +49,7 @@
         jQuery.each(helpContainer, function(index, container){
 --- occu/WebUI/www/config/cp_advancedsettings.cgi.orig
 +++ occu/WebUI/www/config/cp_advancedsettings.cgi
-@@ -0,0 +1,657 @@
+@@ -0,0 +1,662 @@
 +#!/bin/tclsh
 +source once.tcl
 +sourceOnce cgi.tcl
@@ -92,6 +92,11 @@
 +}
 +
 +proc set_systemname { systemname } {
++  # SECURITY: the value is interpolated into a single-quoted ReGaScript string
++  # literal below and executed by ReGaHss as root. Escape backslash and single
++  # quote so an attacker-supplied systemName cannot break out of the literal and
++  # inject arbitrary ReGaScript (e.g. system.Exec). Single pass: \ -> \\, ' -> \'
++  set systemname [string map {\\ \\\\ ' \\'} $systemname]
 +  set isecmd "system.Name('$systemname');"
 +  array set result [rega_script $isecmd]
 +  return $result(STDOUT);

--- a/buildroot-external/patches/occu/0135-WebUI-Add-ControlPanel-AdvancedSettings/occu/WebUI/www/config/cp_advancedsettings.cgi
+++ b/buildroot-external/patches/occu/0135-WebUI-Add-ControlPanel-AdvancedSettings/occu/WebUI/www/config/cp_advancedsettings.cgi
@@ -40,6 +40,11 @@ proc get_systemname {} {
 }
 
 proc set_systemname { systemname } {
+  # SECURITY: the value is interpolated into a single-quoted ReGaScript string
+  # literal below and executed by ReGaHss as root. Escape backslash and single
+  # quote so an attacker-supplied systemName cannot break out of the literal and
+  # inject arbitrary ReGaScript (e.g. system.Exec). Single pass: \ -> \\, ' -> \'
+  set systemname [string map {\\ \\\\ ' \\'} $systemname]
   set isecmd "system.Name('$systemname');"
   array set result [rega_script $isecmd]
   return $result(STDOUT);


### PR DESCRIPTION
Fixes an authenticated ReGaScript injection → root RCE in the WebUI ControlPanel **Advanced Settings** page.

`cp_advancedsettings.cgi`'s `set_systemname` built a ReGaScript string by interpolating the user-supplied `systemName` directly into a single-quoted string literal:

```tcl
set isecmd "system.Name('$systemname');"
```

and executed it via `rega_script`, i.e. in ReGaHss running as **root**. A `systemName` containing a single quote terminated the literal and the remainder was parsed as ReGaScript, allowing an authenticated admin to inject arbitrary ReGaScript (e.g. `system.Exec(...)`) and execute commands as root. `action_save_settings` calls `set_systemname` before any other processing, so the injection fired on every `save_settings` request regardless of the other form fields. On a default install the Admin WebUI account has an empty password, making the precondition trivial to meet.

**Fix:** escape the two ReGaScript string-literal metacharacters before interpolation, in a single `string map` pass (`\` → `\\`, `'` → `\'`):

```tcl
set systemname [string map {\\ \\\\ ' \\'} $systemname]
```

Legitimate names containing apostrophes round-trip unchanged; the injection payload is stored verbatim as the literal system name. Verified end-to-end against a live instance: the PoC payload no longer executes and no canary file is created.

The patch is applied to both copies of the file under the `0135-WebUI-Add-ControlPanel-AdvancedSettings` patch directory.

Closes #3966
Refs: GHSA-6qrx-4wv4-4534


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Advanced Settings" button to Control Panel for configuring system options including watchdog checks, system name, backup settings, feature toggles, and storage checks.
  * Browser page titles now dynamically display your system name or default to "OpenCCU WebUI" when unnamed.
  * Extended tooltip and help system support for advanced settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->