### PR TITLE
eq3_char_loop: return -EAGAIN, not -EFAULT, on full-buffer write

### DIFF
--- a/buildroot-external/package/eq3_char_loop/0006-eq3_char_loop-write-eagain.patch
+++ b/buildroot-external/package/eq3_char_loop/0006-eq3_char_loop-write-eagain.patch
@@ -1,0 +1,58 @@
+eq3_char_loop: report transient buffer-full on write as EAGAIN, not EFAULT
+
+Both eq3loop_write_slave() and eq3loop_write_master() return -EFAULT when the
+ring buffer cannot currently hold a whole frame (CIRC_SPACE < count). -EFAULT
+means "bad userspace address"; here the address is fine and the condition is
+ordinary, transient backpressure. The wrong errno is harmful in practice: the
+HmIP stack (HMIPServer) reaches the slave device through librxtx, which maps
+EFAULT to a fatal java.io.IOException ("Ungueltige Adresse"), so HMIPServer
+treats a recoverable full buffer as unrecoverable and stops writing -- the HmIP
+RF stack then stays dead until a reboot while BidCos keeps working.
+
+Return -EAGAIN instead, so a full buffer is a normal, retryable condition. The
+legitimate -EFAULT returns from copy_from_user() are left untouched. The
+master-side KERN_ERR log line is rate-limited because, under the retryable
+errno, the writer retries and an unthrottled message would flood the kernel log
+(cf. OpenCCU #3407).
+
+This is the minimal, latency-neutral part of the fix. Full backpressure
+(blocking until a whole frame fits) and a distinct -ENODEV for a vanished peer
+are intentionally left as a separate, benchmarked change because multimacd runs
+under SCHED_FIFO.
+
+Refs: OpenCCU #3968
+Upstream: Not applicable
+
+Signed-off-by: Chris <christian.kamien@gmail.com>
+
+--- a/KernelDrivers/eq3_char_loop.c
++++ b/KernelDrivers/eq3_char_loop.c
+@@ -287,7 +287,8 @@
+ 	head = channel->slave2master_buf.head;
+ 	if(CIRC_SPACE( head, channel->slave2master_buf.tail, BUFSIZE) < count)
+ 	{
+-		ret=-EFAULT;
++		/* no room for a whole frame yet -- let the writer retry */
++		ret=-EAGAIN;
+ 		goto out;
+ 	}
+ 	
+@@ -358,9 +359,10 @@
+ 	head = channel->master2slave_buf.head;
+ 	if(CIRC_SPACE( head, channel->master2slave_buf.tail, BUFSIZE) < count)
+ 	{
+-		ret=-EFAULT;
++		/* no room for a whole frame yet -- let the writer retry */
++		ret=-EAGAIN;
+ 		count_to_end = CIRC_SPACE( head, channel->master2slave_buf.tail, BUFSIZE);
+-		printk( KERN_ERR EQ3LOOP_DRIVER_NAME ": eq3loop_write_master() %s: not enough space in buffers. free space = %zu, required space = %zu", channel->name,count_to_end,count );
++		printk_ratelimited( KERN_ERR EQ3LOOP_DRIVER_NAME ": eq3loop_write_master() %s: not enough space in buffers. free space = %zu, required space = %zu", channel->name,count_to_end,count );
+ 		goto out;
+ 	}
+ 	/* ok, space is free, write something */
+@@ -1069,4 +1071,4 @@
+ module_exit(eq3loop_exit);
+ MODULE_DESCRIPTION("eQ-3 IPC loopback char driver");
+ MODULE_LICENSE("GPL");
+-MODULE_VERSION("1.3");
++MODULE_VERSION("1.4");


### PR DESCRIPTION
Minimal, latency-neutral fix for the HmIP-dead-after-`multimacd`-restart root cause analysed in #3968.

`eq3loop_write_slave()` and `eq3loop_write_master()` returned `-EFAULT` when the ring buffer could not currently hold a whole frame (`CIRC_SPACE < count`). `-EFAULT` means "bad userspace address" — but the address is fine; this is ordinary, transient backpressure. HMIPServer reaches the slave device through `librxtx`, which maps `EFAULT` to a fatal `java.io.IOException` ("Ungültige Adresse"), so it treats a recoverable full buffer as unrecoverable and stops writing. The HmIP RF stack then stays dead until a reboot while BidCos keeps working.

This returns **`-EAGAIN`** instead, so a full buffer is a normal, retryable condition. The legitimate `-EFAULT` returns from `copy_from_user()` are left untouched. The master-side `KERN_ERR` log line is changed to `printk_ratelimited` because, under the retryable errno, the writer retries and an unthrottled message would flood the kernel log (cf. #3407).

### Scope
This is deliberately the **minimal** part of the fix. Full backpressure (block until a whole frame fits) and a distinct `-ENODEV` for a vanished peer are left to a separate, benchmarked change, because `multimacd` runs under `SCHED_FIFO` and the blocking change affects writer latency under contention. The errno change here has no latency impact and can ship independently.

### Verification
- Patch applies cleanly on top of the existing `0001`–`0005` series against the pinned tarball (`eq-3/occu` @ `e60183f`); no `.hash` change (patches don't affect the tarball hash). `MODULE_VERSION` bumped `1.3` → `1.4`.
- The `-EFAULT` behaviour was reproduced against the shipped, unmodified module on a generic-x86_64 OpenCCU VM (no RF hardware), and the full field signature confirmed on a live HB-RF-ETH install — details in #3968.

Refs #3968


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling for ring buffer capacity conditions in the kernel driver by returning `-EAGAIN` when a full frame can’t fit, instead of treating it as a fault.
  * Reduced excessive kernel logging during high-load retries by rate-limiting the related error message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

### Testing wanted (hardware)

I don't have an OpenCCU box with radio hardware to confirm this live (the reproduction was RF-less + a debmatic field capture, see #3968). If you have one, it's quick to verify:

1. Build an OpenCCU image with this patch.
2. With `HMIPServer` running, induce the loopback-full condition that produced the fatal exception — e.g. a lone `multimacd` restart (see #3970) that orphans `/dev/mmd_hmip`.
3. **Before:** `hmserver.log` shows fatal `java.io.IOException: Ungültige Adresse in writeArray`. **After:** that fatal exception should no longer appear (a full buffer now returns the benign `EAGAIN` instead of `EFAULT`).

Results welcome.
