### PR TITLE
S60multimacd: coordinate RF-stack teardown for a clean restart

### DIFF
--- a/buildroot-external/overlay/RFD/etc/init.d/S60multimacd
+++ b/buildroot-external/overlay/RFD/etc/init.d/S60multimacd
@@ -75,6 +75,32 @@ waitStartupComplete() {
   done
 }
 
+# Stop the RF-stack consumers (rfd, HMIPServer) that hold the eq3loop slave
+# devices. They must be stopped before the module can be unloaded; otherwise
+# rmmod fails "in use", the module stays half-wedged, and the HmIP stack dies
+# until the next reboot.
+stop_consumers() {
+  [[ -x /etc/init.d/S62HMServer ]] && /etc/init.d/S62HMServer stop
+  [[ -x /etc/init.d/S61rfd ]] && /etc/init.d/S61rfd stop
+}
+
+# Start the consumers again, in order, after multimacd has recreated the
+# mmd_* devices.
+start_consumers() {
+  [[ -x /etc/init.d/S61rfd ]] && /etc/init.d/S61rfd start
+  [[ -x /etc/init.d/S62HMServer ]] && /etc/init.d/S62HMServer start
+}
+
+# Assert a coprocessor/radio reset so the HmIP coprocessor app re-handshakes
+# after the stack was torn down (mirrors S47InitRFHardware's reset_rf_hardware).
+reset_radio() {
+  for rdev in /sys/class/raw-uart/*/reset_radio_module; do
+    [[ -e "${rdev}" ]] && echo 1 >"${rdev}" 2>/dev/null
+  done
+  # give the RF module some time to stabilize after the reset
+  sleep 2
+}
+
 start() {
   echo -n "Starting multimacd: "
 
@@ -120,22 +146,54 @@ stop() {
     start-stop-daemon -K -q -p ${PIDFILE}
     rm -f ${PIDFILE}
     echo "OK"
-
-    # make sure to unload eq3_char_loop which
-    # is necessary for docker-based environments
-    if [[ -c /dev/eq3loop ]]; then
-      sleep 2 # wait to settle
-      # load eq3_char_loop kernel module
-      rmmod eq3_char_loop 2>/dev/null
-    fi
   else
     echo "not started"
+  fi
+
+  # make sure to unload eq3_char_loop which is necessary for docker-based
+  # environments and for a clean RF-stack restart.
+  if [[ -c /dev/eq3loop ]]; then
+    # release the slave devices first: rfd and HMIPServer keep mmd_bidcos /
+    # mmd_hmip open, so without stopping them rmmod fails "in use" and the
+    # module stays half-wedged (HmIP dead until reboot).
+    stop_consumers
+    # backstop: kill anything still holding the slave nodes
+    fuser -k /dev/mmd_bidcos /dev/mmd_hmip >/dev/null 2>&1
+    # clear stale RXTX lock files so HMIPServer can reopen after a restart
+    rm -f /var/lock/LCK..mmd_bidcos /var/lock/LCK..mmd_hmip
+    sleep 1 # let holders settle
+
+    # unload, retrying briefly while consumers finish releasing the devices.
+    # Do not silently swallow a persistent failure -- log it.
+    i=0
+    while [[ ${i} -lt ${STEPS} ]] && [[ -c /dev/eq3loop ]]; do
+      rmmod eq3_char_loop 2>/dev/null && break
+      i=$((i + 1))
+      sleep 1
+    done
+    if [[ -c /dev/eq3loop ]]; then
+      echo "WARNING: could not unload eq3_char_loop (still in use)"
+    fi
   fi
 }
 
 restart() {
+  # remember whether we are the eq3loop coordinator before tearing down, so a
+  # plain (non-eq3loop) setup keeps the old simple stop/start semantics.
+  COORDINATE=0
+  [[ -c /dev/eq3loop ]] && COORDINATE=1
+
   stop
-  start
+
+  if [[ ${COORDINATE} -eq 1 ]]; then
+    # the module is unloaded and the slaves are released; reset the radio so
+    # the coprocessor re-handshakes, then bring the stack back up in order.
+    reset_radio
+    start
+    start_consumers
+  else
+    start
+  fi
 }
 
 case "$1" in


### PR DESCRIPTION
Second half of the fix for #3968 (defect **b**, the init-orchestration gap). Complements #3969 (the kernel-driver errno change); this one makes a `multimacd` restart actually rebuild the RF stack instead of leaving it half-wedged.

### Problem
`S60multimacd stop()`/`restart()` killed only `multimacd` and then ran `rmmod eq3_char_loop 2>/dev/null`. But `rfd` and `HMIPServer` keep the eq3loop slave devices (`mmd_bidcos`/`mmd_hmip`) open, so `rmmod` fails **in use** (error swallowed) and the module stays half-wedged. HMIPServer's next write then hits a full, undrained buffer and the HmIP stack stays dead (BidCos keeps working) until a reboot — and the stale RXTX lock + un-reset coprocessor block recovery even on a later restart. See #3968 for the full chain and the field/repro evidence.

### Change
Make a `multimacd` restart a *coordinated* RF-stack restart:
- **`stop()`** — stop the consumers (`S62HMServer`, `S61rfd`) before `rmmod` so the slaves are released; `fuser -k` as a backstop; clear the stale `LCK..mmd_*` lock files; retry `rmmod` and **log** a persistent failure instead of swallowing it.
- **`restart()`** — assert the coprocessor reset (raw-uart `reset_radio_module`, same mechanism as `S47InitRFHardware`) so the HmIP coprocessor app re-handshakes, then bring `multimacd → rfd → HMIPServer` back up in order.

Plain (non-eq3loop) setups keep the previous simple stop/start semantics (guarded on `/dev/eq3loop`).

### ⚠ Needs validation on OpenCCU hardware
This is OpenCCU's `S60multimacd` sysvinit script. A stock eQ-3 CCU3 doesn't run it, and debmatic uses systemd units (`debmatic-multimacd.service`) rather than this script, so neither is a test target here. It needs testing on an **OpenCCU install on real hardware with a radio** — a locally-attached RPI-RF-MOD / HM-MOD-RPI-PCB (GPIO/UART) is enough to exercise the consumer release, lock cleanup, `rmmod`, radio reset and ordered restart; the RF-less dev VM can't. On hb-rf-eth (remote-radio) setups the coprocessor handshake is slower, so `waitStartupComplete`'s poll may need more headroom there. Syntax is checked (`bash -n`, shellcheck clean).

The debmatic systemd packaging (`debmatic-multimacd.service`) has the equivalent gap and needs a parallel fix via unit ordering.

Refs #3968


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced service stop and restart procedures with improved device cleanup and recovery mechanisms
  * Added radio reset functionality for more reliable RF-stack management and recovery

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

### Testing wanted (hardware)

Needs an OpenCCU box with a radio (a local RPI-RF-MOD / HM-MOD-RPI-PCB is enough). To confirm:

1. **Without** this change: with the stack up, run `/etc/init.d/S60multimacd restart`. Expect HmIP to go dead (devices UNREACH), `rmmod: ... is in use`, `No Coprocessor detected`, recovery only via reboot.
2. **With** this change: same `S60multimacd restart`. Expect a clean teardown (consumers stopped, module unloaded, locks cleared, radio reset) and both stacks back up with no reboot.
3. Verify via `rfd` XML-RPC `listBidcosInterfaces`: BidCos-RF **and** HmIP `CONNECTED=true`.

On hb-rf-eth (remote radio) the handshake is slower, so watch that `waitStartupComplete` has enough headroom on that path. Results welcome.
