### PR TITLE
bump occu to 3.89.3-1

### DIFF
--- a/buildroot-external/package/occu/occu.hash
+++ b/buildroot-external/package/occu/occu.hash
@@ -1,3 +1,3 @@
 # Locally computed
 sha256  e600b8a501a17600d01bd7a4646508f94f3cd3b9df03661babd9f1801e579b36  LicenseDE.txt
-sha256  d6de8b4b570a8b8f48bf6ae8bf2d9ab21b15de9e26963680b1b9bfb3faf2ca48  occu-3.89.2-1.tar.gz
+sha256  a007589d58e2ddc4c0ca48c3f0fded43a1dfc2d73a501bd4ca534f7a1c38e4b9  occu-3.89.3-1.tar.gz

--- a/buildroot-external/package/occu/occu.mk
+++ b/buildroot-external/package/occu/occu.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-OCCU_VERSION = 3.89.2-1
+OCCU_VERSION = 3.89.3-1
 OCCU_SITE = $(call github,OpenCCU,occu,$(OCCU_VERSION))
 OCCU_LICENSE = HMSL
 OCCU_LICENSE_FILES = LicenseDE.txt


### PR DESCRIPTION
Dependency update generated by nightly update check workflow.

Updated component:
- Name...: `occu`
- Package: `occu`
- Current version: `3.89.2-1`
- New version....: `3.89.3-1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OCCU package to version 3.89.3-1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->