### PR TITLE
bump OpenCCU HA Proxy App to 0.6.1

### DIFF
--- a/home-assistant-addon-proxy/CHANGELOG.md
+++ b/home-assistant-addon-proxy/CHANGELOG.md
@@ -1,5 +1,8 @@
 # ChangeLog
 
+## 0.6.1
+- Bump http-proxy-middleware dependency to 4.1.1
+
 ## 0.6.0
 - migrate the proxy add-on from the deprecated `base-nodejs` image to the general app-base (`base`) image.
 - stage the Node.js runtime and proxy dependencies explicitly and let the app-base init system manage process startup via the add-on `services` startup mode.

--- a/home-assistant-addon-proxy/config.yaml
+++ b/home-assistant-addon-proxy/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: OpenCCU (Proxy)
-version: 0.6.0
+version: 0.6.1
 slug: openccu_proxy
 image: ghcr.io/openccu/openccu-proxy
 arch:

--- a/home-assistant-addon-proxy/package-lock.json
+++ b/home-assistant-addon-proxy/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openccu-ha-proxy",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openccu-ha-proxy",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "Apache-2.0",
       "dependencies": {
         "express": "5.2.1",

--- a/home-assistant-addon-proxy/package.json
+++ b/home-assistant-addon-proxy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openccu-ha-proxy",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Proxy to externally running OpenCCU for Home Assistant ingress",
   "main": "ha-proxy.js",
   "private": true,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped the add-on proxy version to **0.6.1** and updated its changelog entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->