### PR TITLE
fix S11MountAll to also recognize GPT PARTUUIDs correctly

### DIFF
--- a/buildroot-external/package/recovery-system/external/overlay/base/etc/init.d/S11MountAll
+++ b/buildroot-external/package/recovery-system/external/overlay/base/etc/init.d/S11MountAll
@@ -13,7 +13,7 @@ start() {
 
   # shellcheck disable=SC2034
   for i in $(seq 1 ${MAXSTEPS}); do
-    if /sbin/blkid | grep -E -i -q 'PARTUUID="deedbeef-.*(01)"'
+    if /sbin/blkid | grep -E -i -q 'PARTUUID="deedbeef-.*(01)"'; then
       FOUND=1
       break
     fi

--- a/buildroot-external/package/recovery-system/external/overlay/base/etc/init.d/S11MountAll
+++ b/buildroot-external/package/recovery-system/external/overlay/base/etc/init.d/S11MountAll
@@ -9,16 +9,19 @@ start() {
 
   # wait until bootfs is actually ready to be mounted
   MAXSTEPS=120
+  FOUND=0
+
   # shellcheck disable=SC2034
   for i in $(seq 1 ${MAXSTEPS}); do
-    if /sbin/blkid | grep -q deedbeef-01; then
+    if /sbin/blkid | grep -E -i -q 'PARTUUID="deedbeef-.*(01)"'
+      FOUND=1
       break
     fi
     sleep 2
     echo -n "."
   done
 
-  if ! /sbin/blkid | grep -q deedbeef-01; then
+  if [[ ${FOUND} -ne 1 ]]; then
     echo "ERROR: bootfs did not show up in time."
     exit 1
   fi

--- a/buildroot-external/package/recovery-system/recovery-system.mk
+++ b/buildroot-external/package/recovery-system/recovery-system.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-RECOVERY_SYSTEM_VER = 1.24.0
+RECOVERY_SYSTEM_VER = 1.24.1
 RECOVERY_SYSTEM_VERSION = $(RECOVERY_SYSTEM_VER)-$(BR2_VERSION)
 RECOVERY_SYSTEM_SOURCE =
 RECOVERY_SYSTEM_LICENSE = Apache-2.0


### PR DESCRIPTION
This fixes the mount all operation in S11MountAll to also correctly identify a bootfs partition if a GPT driven partition layout is used (like with the generic-aarch64 or generic-x86_64 platforms).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved boot partition detection during startup, making the recovery system more reliable on slower device enumeration.
  * Added a clearer error when the boot filesystem does not appear within the expected time window.

* **Chores**
  * Updated the recovery system version to **1.24.1**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->