### PR TITLE
fix disk signature reset to work on DOS/MBR partitions only.

### DIFF
--- a/buildroot-external/overlay/base/etc/init.d/S03CheckUserFSResize
+++ b/buildroot-external/overlay/base/etc/init.d/S03CheckUserFSResize
@@ -54,8 +54,17 @@ check_userfs_resize() {
         return 2
       fi
 
-      # force PARTUUID to 0xDEEDBEEF because parted changes partuuid
-      echo -en '\xEF\xBE\xED\xDE' | dd of="${DEV}" conv=notrunc bs=1 seek=$((0x1B8)) 2>/dev/null
+      # set MBR disk signature in case we have a dos/mbr partitioning
+      PTTYPE="$(/sbin/blkid -o value -s PTTYPE "${DEV}" 2>/dev/null || true)"
+      case "${PTTYPE}" in
+        dos)
+          # MBR: required because parted resets disk signature, thus PARTUUID will be different
+          echo -en '\xEF\xBE\xED\xDE' | /bin/dd of="${DEV}" conv=notrunc bs=1 seek=$((0x1B8)) 2>/dev/null
+          ;;
+        gpt)
+          # GPT: not required; GPT-PARTUUID comes from unique partition GUID
+          ;;
+      esac
 
       # check if we need to resize the filesystem as well or if we skip it
       # since a factory reset is anyway done in the next step

--- a/buildroot-external/overlay/base/etc/init.d/S04CheckFactoryReset
+++ b/buildroot-external/overlay/base/etc/init.d/S04CheckFactoryReset
@@ -26,12 +26,21 @@ check_factory_reset() {
     # umount /usr/local to regenerate it
     umount -f /usr/local
 
-    # force PARTUUID to 0xDEEDBEEF because due to some tools the
-    # correct partuuid might have been lost
-    PARTUUID=$(/sbin/blkid -o export "${DEVNAME}" | grep -m1 PARTUUID | cut -d= -f2)
-    if [[ "${PARTUUID}" != "deedbeef-03" ]]; then
-      echo -en '\xEF\xBE\xED\xDE' | dd of="${DEV}" conv=notrunc bs=1 seek=$((0x1B8)) 2>/dev/null
-    fi
+    # reset MBR disk signature (thus PARTUUID to 0xDEEDBEEF)
+    # because due to some tools the correct partuuid might have been lost
+    PTTYPE="$(/sbin/blkid -o value -s PTTYPE "${DEV}" 2>/dev/null || true)"
+    case "${PTTYPE}" in
+      dos)
+        # MBR: required because parted resets disk signature, thus PARTUUID will be different
+        PARTUUID=$(/sbin/blkid -o export "${DEVNAME}" | grep -m1 PARTUUID | cut -d= -f2)
+        if [[ "${PARTUUID}" != "deedbeef-03" ]]; then
+          echo -en '\xEF\xBE\xED\xDE' | /bin/dd of="${DEV}" conv=notrunc bs=1 seek=$((0x1B8)) 2>/dev/null
+        fi
+        ;;
+      gpt)
+        # GPT: not required; GPT-PARTUUID comes from unique partition GUID
+        ;;
+    esac
 
     # we create a clean ext4 partition now
     /sbin/mkfs.ext4 -F -L userfs -I 256 -E lazy_itable_init=0,lazy_journal_init=0 "${DEVNAME}"

--- a/buildroot-external/package/recovery-system/external/overlay/base/bin/fwinstall.sh
+++ b/buildroot-external/package/recovery-system/external/overlay/base/bin/fwinstall.sh
@@ -114,8 +114,17 @@ expand_userfs_to_max()
     return 2
   fi
 
-  # force PARTUUID to 0xDEEDBEEF because parted changes partuuid
-  echo -en '\xEF\xBE\xED\xDE' | /bin/dd of="${DISK_DEV}" conv=notrunc bs=1 seek=$((0x1B8)) 2>/dev/null
+  # set MBR disk signature in case we have a dos/mbr partitioning
+  PTTYPE="$(/sbin/blkid -o value -s PTTYPE "${DISK_DEV}" 2>/dev/null || true)"
+  case "${PTTYPE}" in
+    dos)
+      # MBR: required because parted resets disk signature, thus PARTUUID will be different
+      echo -en '\xEF\xBE\xED\xDE' | /bin/dd of="${DISK_DEV}" conv=notrunc bs=1 seek=$((0x1B8)) 2>/dev/null
+      ;;
+    gpt)
+      # GPT: not required; GPT-PARTUUID comes from unique partition GUID
+      ;;
+  esac
 
   # use partprobe to query for updated parttable
   partprobe "${DISK_DEV}" 2>/dev/null || true


### PR DESCRIPTION
This changed the logic to reset the MBR disk signature to only enfore a new 0xdeedbeef disk signature in case DOS/MBR partition layouts are used so that no unnecessary GPT partition modifications are performed anymore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved disk-signature handling during user filesystem resize and factory reset.
  * The system now detects whether a device uses MBR or GPT and applies legacy signature updates only on MBR disks.
  * GPT-based devices no longer receive MBR-specific signature writes, reducing the risk of incorrect partition ID changes during maintenance operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->