### PR TITLE
fix missing /var/lib upon seedrng start in recoveryfs

### DIFF
--- a/buildroot-external/package/recovery-system/external/overlay/base/etc/init.d/S05seedrng
+++ b/buildroot-external/package/recovery-system/external/overlay/base/etc/init.d/S05seedrng
@@ -1,5 +1,5 @@
 #!/bin/sh
-# shellcheck shell=dash disable=SC2169
+# shellcheck shell=dash disable=SC2169,SC3010
 #
 # Startup script to seed the kernel RNG and preserve it during reboots.
 #
@@ -15,6 +15,10 @@ SEEDRNG_ARGS="-d /var/lib/seedrng"
 case "$1" in
 	start|stop|restart|reload)
 		echo -n "Running ${DAEMON}: "
+
+		# make sure /var/lib exists
+		# shellcheck disable=SC2174
+		mkdir -p -m 0775 /var/lib
 
 		# shellcheck disable=SC2086 # we need the word splitting
 		/usr/sbin/seedrng ${SEEDRNG_ARGS} >/dev/null


### PR DESCRIPTION
This fixes directory exists errors upon seedrng startup in the recoveryfs which was cause by /var/lib not existing at the time seedrng is started.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved early boot initialization so the random seed service can reliably start, stop, restart, and reload.
  * Ensured the required system directory is created automatically before the service runs, preventing failures on first use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->