### PR TITLE
bump rpi-eeprom to aa33b8d

### DIFF
--- a/buildroot-external/package/rpi-eeprom/rpi-eeprom.hash
+++ b/buildroot-external/package/rpi-eeprom/rpi-eeprom.hash
@@ -1,3 +1,3 @@
 # Locally computed
 sha256  594b7565fd3ccf8acd4711a2ec1b199181aafbc3426d0bacaa50ef40edbf7c4a  LICENSE
-sha256  d37fcdd94abb65c43855575f934a4af34b8d3294f79042270ee6f1c7ee209409  rpi-eeprom-32e85eda5c86982d8309a6e6bcbaebfa45220b04.tar.gz
+sha256  861d58100e2edccbb7a788d03daf6e71a39972023310eaff0bdb6298c8c25998  rpi-eeprom-aa33b8dc7cee51de4b75580095521dea50407d6e.tar.gz

--- a/buildroot-external/package/rpi-eeprom/rpi-eeprom.mk
+++ b/buildroot-external/package/rpi-eeprom/rpi-eeprom.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-RPI_EEPROM_VERSION = 32e85eda5c86982d8309a6e6bcbaebfa45220b04
+RPI_EEPROM_VERSION = aa33b8dc7cee51de4b75580095521dea50407d6e
 RPI_EEPROM_SITE = $(call github,raspberrypi,rpi-eeprom,$(RPI_EEPROM_VERSION))
 RPI_EEPROM_LICENSE = BSD-3-Clause, MIT, uIP, custom
 RPI_EEPROM_LICENSE_FILES = LICENSE
@@ -17,7 +17,7 @@ ifeq ($(BR2_PACKAGE_RPI_EEPROM_RPI4),y)
   RPI_EEPROM_VL805_GLOB = firmware-2711/stable/vl805-*.bin
 else ifeq ($(BR2_PACKAGE_RPI_EEPROM_RPI5),y)
   # Raspberry Pi 5 (2712)
-  RPI_EEPROM_FIRMWARE_PATH = firmware-2712/stable/pieeprom-2026-06-17.bin
+  RPI_EEPROM_FIRMWARE_PATH = firmware-2712/stable/pieeprom-2026-06-29.bin
   RPI_EEPROM_RECOVERY_PATH = firmware-2712/stable/recovery.bin
 endif
 


### PR DESCRIPTION
Dependency update generated by nightly update check workflow.

Updated component:
- Name...: `rpi-eeprom`
- Package: `rpi-eeprom`
- Current version: `32e85ed`
- New version....: `aa33b8d`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Raspberry Pi EEPROM package to a newer upstream revision.
  * Switched the Raspberry Pi 5 firmware image to a newer stable release, which may improve device compatibility and reliability.
  * Refreshed the package checksum to match the updated source archive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->