### PR TITLE
bump occu to 3.89.6-1

### DIFF
--- a/buildroot-external/package/occu/occu.hash
+++ b/buildroot-external/package/occu/occu.hash
@@ -1,3 +1,3 @@
 # Locally computed
 sha256  e600b8a501a17600d01bd7a4646508f94f3cd3b9df03661babd9f1801e579b36  LicenseDE.txt
-sha256  f4b98c0ffd078c8944f134c323a30199309dc397e01ddcf051969e66e83c8a7b  occu-3.89.5-1.tar.gz
+sha256  3402c68e621fdc4666c5df6ede732d6d74fa8ff0dab7e14f670f4cd728fe7ba2  occu-3.89.6-1.tar.gz

--- a/buildroot-external/package/occu/occu.mk
+++ b/buildroot-external/package/occu/occu.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-OCCU_VERSION = 3.89.5-1
+OCCU_VERSION = 3.89.6-1
 OCCU_SITE = $(call github,OpenCCU,occu,$(OCCU_VERSION))
 OCCU_LICENSE = HMSL
 OCCU_LICENSE_FILES = LicenseDE.txt


### PR DESCRIPTION
Dependency update generated by nightly update check workflow.

Updated component:
- Name...: `occu`
- Package: `occu`
- Current version: `3.89.5-1`
- New version....: `3.89.6-1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the OCCU package to a newer upstream release, so builds now use version 3.89.6-1.
  * Refreshed the package checksum to match the new source archive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->