### PR TITLE
bump tailscale to 1.98.9

### DIFF
--- a/buildroot-external/package/tailscale-bin/tailscale-bin.hash
+++ b/buildroot-external/package/tailscale-bin/tailscale-bin.hash
@@ -1,4 +1,4 @@
 # Locally computed
 sha256  a7ca6186a7963a0a60740f6047760eecd7a0234e8c38bd7e1e0bbcb324bda45b  LICENSE
-sha256  3a55b5900dd7e11e09b6c74d1e46d223d549dfbefbdc1f044a8ab7bdbafb933c  tailscale_1.98.8_amd64.tgz
-sha256  53eb3ce89d062fd34e393d24a6c8ec08c769fede8eb77fe9c6e347ad4ae00f84  tailscale_1.98.8_arm64.tgz
+sha256  11be30ad301d48f84ff52fec34f8a2f78eb3e3dee1be4e9624d19fccc8df5540  tailscale_1.98.9_amd64.tgz
+sha256  fa554ee808d7d07ee8e3ebbc0215ea087157e2a0abbf408e6e18ea7532554db6  tailscale_1.98.9_arm64.tgz

--- a/buildroot-external/package/tailscale-bin/tailscale-bin.mk
+++ b/buildroot-external/package/tailscale-bin/tailscale-bin.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-TAILSCALE_BIN_VERSION = 1.98.8
+TAILSCALE_BIN_VERSION = 1.98.9
 TAILSCALE_BIN_SITE = https://pkgs.tailscale.com/stable
 ifeq ($(call qstrip,$(BR2_ARCH)),aarch64)
 TAILSCALE_BIN_SOURCE = tailscale_$(TAILSCALE_BIN_VERSION)_arm64.tgz


### PR DESCRIPTION
Dependency update generated by nightly update check workflow.

Updated component:
- Name...: `tailscale`
- Package: `tailscale-bin`
- Current version: `1.98.8`
- New version....: `1.98.9`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated the included Tailscale package from version 1.98.8 to 1.98.9.
  - Updated the associated binary verification data for supported architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->