### PR TITLE
add some more kernel config options for generic-x86_64

### DIFF
--- a/buildroot-external/board/generic-x86_64/kernel.config
+++ b/buildroot-external/board/generic-x86_64/kernel.config
@@ -96,6 +96,15 @@ CONFIG_BMP280=m
 # Required for some PCIe devices such as ath12k
 CONFIG_IRQ_REMAP=y
 
+# Internal NVMe devices behind Intel Volume Management Device
+CONFIG_VMD=y
+
+# Pin control support
+CONFIG_PINCTRL_CANNONLAKE=m
+
+# Network devices
+CONFIG_MARVELL_PHY=m
+
 CONFIG_CPU_FREQ_STAT=y
 CONFIG_CPU_FREQ_GOV_POWERSAVE=y
 CONFIG_CPU_FREQ_GOV_CONSERVATIVE=y


### PR DESCRIPTION
This PR adds CONFIG_VMD, CONFIG_PINCTRL_CANNONLAKE and CONFIG_MARVELL_PHY for improved hardware support for the generic-x86_64 platform. (cf. https://github.com/home-assistant/operating-system/pull/4902, https://github.com/home-assistant/operating-system/pull/4091, https://github.com/home-assistant/operating-system/pull/4105)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for NVMe devices behind Intel Volume Management Device (VMD).
  * Added Cannon Lake pin control support.
  * Added Marvell Ethernet PHY support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->