### PR TITLE
bump rpi-eeprom to bade0f6

### DIFF
--- a/buildroot-external/package/rpi-eeprom/rpi-eeprom.hash
+++ b/buildroot-external/package/rpi-eeprom/rpi-eeprom.hash
@@ -1,3 +1,3 @@
 # Locally computed
 sha256  594b7565fd3ccf8acd4711a2ec1b199181aafbc3426d0bacaa50ef40edbf7c4a  LICENSE
-sha256  861d58100e2edccbb7a788d03daf6e71a39972023310eaff0bdb6298c8c25998  rpi-eeprom-aa33b8dc7cee51de4b75580095521dea50407d6e.tar.gz
+sha256  11764aebdc4c3b98ded01e322b1b26c45ad796e1c54faa93547c7561b044f073  rpi-eeprom-bade0f69d5e5add2610fc57db9ca42694443c98b.tar.gz

--- a/buildroot-external/package/rpi-eeprom/rpi-eeprom.mk
+++ b/buildroot-external/package/rpi-eeprom/rpi-eeprom.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-RPI_EEPROM_VERSION = aa33b8dc7cee51de4b75580095521dea50407d6e
+RPI_EEPROM_VERSION = bade0f69d5e5add2610fc57db9ca42694443c98b
 RPI_EEPROM_SITE = $(call github,raspberrypi,rpi-eeprom,$(RPI_EEPROM_VERSION))
 RPI_EEPROM_LICENSE = BSD-3-Clause, MIT, uIP, custom
 RPI_EEPROM_LICENSE_FILES = LICENSE


### PR DESCRIPTION
Dependency update generated by nightly update check workflow.

Updated component:
- Name...: `rpi-eeprom`
- Package: `rpi-eeprom`
- Current version: `aa33b8d`
- New version....: `bade0f6`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the bundled Raspberry Pi EEPROM firmware package to a newer upstream release.
  * Updated the associated download verification checksum to match the new firmware artifact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->