### PR TITLE
bump rpi-eeprom to 08af920

### DIFF
--- a/buildroot-external/package/rpi-eeprom/rpi-eeprom.hash
+++ b/buildroot-external/package/rpi-eeprom/rpi-eeprom.hash
@@ -1,3 +1,3 @@
 # Locally computed
 sha256  594b7565fd3ccf8acd4711a2ec1b199181aafbc3426d0bacaa50ef40edbf7c4a  LICENSE
-sha256  11764aebdc4c3b98ded01e322b1b26c45ad796e1c54faa93547c7561b044f073  rpi-eeprom-bade0f69d5e5add2610fc57db9ca42694443c98b.tar.gz
+sha256  0d71a6304cd594c37a31f7ceae010d99fb6ece4ab62ea4242d3bfc681a8cf5f3  rpi-eeprom-08af920bb6402cb0488aa8168a927dd4a355b971.tar.gz

--- a/buildroot-external/package/rpi-eeprom/rpi-eeprom.mk
+++ b/buildroot-external/package/rpi-eeprom/rpi-eeprom.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-RPI_EEPROM_VERSION = bade0f69d5e5add2610fc57db9ca42694443c98b
+RPI_EEPROM_VERSION = 08af920bb6402cb0488aa8168a927dd4a355b971
 RPI_EEPROM_SITE = $(call github,raspberrypi,rpi-eeprom,$(RPI_EEPROM_VERSION))
 RPI_EEPROM_LICENSE = BSD-3-Clause, MIT, uIP, custom
 RPI_EEPROM_LICENSE_FILES = LICENSE


### PR DESCRIPTION
Dependency update generated by nightly update check workflow.

Updated component:
- Name...: `rpi-eeprom`
- Package: `rpi-eeprom`
- Current version: `bade0f6`
- New version....: `08af920`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the Raspberry Pi EEPROM package to a newer upstream revision.
  * Refreshed the associated source archive and verification checksum.
  * Existing license verification remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->