### PR TITLE
bump tailscale to 1.102.2

### DIFF
--- a/buildroot-external/package/tailscale-bin/tailscale-bin.hash
+++ b/buildroot-external/package/tailscale-bin/tailscale-bin.hash
@@ -1,4 +1,4 @@
 # Locally computed
 sha256  a7ca6186a7963a0a60740f6047760eecd7a0234e8c38bd7e1e0bbcb324bda45b  LICENSE
-sha256  4eab0d2c268ec1f81dc50a5ef9805ea993fc08dc52ede5a6d8ddd44ef6f9df0f  tailscale_1.102.1_amd64.tgz
-sha256  43973827540d8a4db44b6b662037e8e75c98a2797cef1ce76d214becc48c470c  tailscale_1.102.1_arm64.tgz
+sha256  ad2cde12f8de95f7b93a1e0401e652291c603d42b9d60a33fb1741eb38ab04d8  tailscale_1.102.2_amd64.tgz
+sha256  2b64e9ade7e73034b5ec9e9bcd537f5ddd14ae3abb435e57e929e7486ae42660  tailscale_1.102.2_arm64.tgz

--- a/buildroot-external/package/tailscale-bin/tailscale-bin.mk
+++ b/buildroot-external/package/tailscale-bin/tailscale-bin.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-TAILSCALE_BIN_VERSION = 1.102.1
+TAILSCALE_BIN_VERSION = 1.102.2
 TAILSCALE_BIN_SITE = https://pkgs.tailscale.com/stable
 ifeq ($(call qstrip,$(BR2_ARCH)),aarch64)
 TAILSCALE_BIN_SOURCE = tailscale_$(TAILSCALE_BIN_VERSION)_arm64.tgz


### PR DESCRIPTION
Dependency update generated by nightly update check workflow.

Updated component:
- Name...: `tailscale`
- Package: `tailscale-bin`
- Current version: `1.102.1`
- New version....: `1.102.2`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the included Tailscale package to version 1.102.2.
  * Refreshed package verification data for supported amd64 and arm64 builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->