### PR TITLE
Relocate Rasberry Pi FDT out of the CMA alloc-range

### DIFF
--- a/buildroot-external/board/rpi3/boot.cmd
+++ b/buildroot-external/board/rpi3/boot.cmd
@@ -44,7 +44,8 @@ else
 fi
 
 # load devicetree
-fdt addr ${fdt_addr}
+setenv fdt_org ${fdt_addr}
+fdt addr ${fdt_org}
 fdt get value bootargs /chosen bootargs
 
 # set bootargs
@@ -53,7 +54,12 @@ setenv bootargs "dwc_otg.lpm_enable=0 sdhci_bcm2708.enable_llm=0 console=${conso
 # load kernel
 load ${devtype} ${devnum}:${kernelfs} ${kernel_addr_r} ${kernel_img}
 
+# Relocate the FDT below the firmware-provided one, otherwise it ends up just
+# below 512 MiB and fragments the CMA alloc-range (first 768 MiB on BCM2711)
+setenv fdt_high ${fdt_org}
+
 # boot kernel
+echo "Starting kernel"
 ${kernel_bootcmd} ${kernel_addr_r} ${initrd_addr_r} ${fdt_addr}
 
 echo "Boot failed, resetting..."

--- a/buildroot-external/board/rpi4/boot.cmd
+++ b/buildroot-external/board/rpi4/boot.cmd
@@ -44,7 +44,8 @@ else
 fi
 
 # load devicetree
-fdt addr ${fdt_addr}
+setenv fdt_org ${fdt_addr}
+fdt addr ${fdt_org}
 fdt get value bootargs /chosen bootargs
 
 # set bootargs
@@ -53,7 +54,12 @@ setenv bootargs "dwc_otg.lpm_enable=0 sdhci_bcm2708.enable_llm=0 console=${conso
 # load kernel
 load ${devtype} ${devnum}:${kernelfs} ${kernel_addr_r} ${kernel_img}
 
+# Relocate the FDT below the firmware-provided one, otherwise it ends up just
+# below 512 MiB and fragments the CMA alloc-range (first 768 MiB on BCM2711)
+setenv fdt_high ${fdt_org}
+
 # boot kernel
+echo "Starting kernel"
 ${kernel_bootcmd} ${kernel_addr_r} ${initrd_addr_r} ${fdt_addr}
 
 echo "Boot failed, resetting..."

--- a/buildroot-external/board/rpi5/boot.cmd
+++ b/buildroot-external/board/rpi5/boot.cmd
@@ -44,7 +44,8 @@ else
 fi
 
 # load devicetree
-fdt addr ${fdt_addr}
+setenv fdt_org ${fdt_addr}
+fdt addr ${fdt_org}
 fdt get value bootargs /chosen bootargs
 
 # set bootargs
@@ -53,7 +54,12 @@ setenv bootargs "dwc_otg.lpm_enable=0 sdhci_bcm2708.enable_llm=0 console=${conso
 # load kernel
 load ${devtype} ${devnum}:${kernelfs} ${kernel_addr_r} ${kernel_img}
 
+# Relocate the FDT below the firmware-provided one, otherwise it ends up just
+# below 512 MiB and fragments the CMA alloc-range (first 768 MiB on BCM2711)
+setenv fdt_high ${fdt_org}
+
 # boot kernel
+echo "Starting kernel"
 ${kernel_bootcmd} ${kernel_addr_r} ${initrd_addr_r} ${fdt_addr}
 
 echo "Boot failed, resetting..."


### PR DESCRIPTION
This PR implements the same change like in Home Assistant OS to set fdt_high to the firmware-provided FDT address so U-Boot places its copy right below it, above the CMA alloc-range.
(cf. https://github.com/home-assistant/operating-system/pull/4954)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device tree handling during boot across Raspberry Pi 3, 4, and 5 platforms.
  * Reduced potential memory placement issues by constraining device tree relocation.

* **User Experience**
  * Added a “Starting kernel” message before the operating system begins booting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->