### PR TITLE
fix qemu-guest-agent 11.1.0 build remoing --disable-glusterfs

### DIFF
--- a/buildroot-external/package/qemu-guest-agent/qemu-guest-agent.mk
+++ b/buildroot-external/package/qemu-guest-agent/qemu-guest-agent.mk
@@ -90,7 +90,6 @@ define QEMU_GUEST_AGENT_CONFIGURE_CMDS
 			--disable-bzip2 \
 			--disable-seccomp \
 			--disable-coroutine-pool \
-			--disable-glusterfs \
 			--disable-tpm \
 			--disable-numa \
 			--disable-capstone \


### PR DESCRIPTION
This PR removes the --disable-glusterfs configure option for the qemu-guest-agent build since this is option does not exist anymore since upgrading to 11.1.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * QEMU Guest Agent builds now retain GlusterFS support, enabling compatibility with GlusterFS-backed environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->