### PR TITLE
fix UPnP/SSDP UDN changes for oci/HA use

### DIFF
--- a/buildroot-external/overlay/base/etc/init.d/S47InitRFHardware
+++ b/buildroot-external/overlay/base/etc/init.d/S47InitRFHardware
@@ -1,5 +1,5 @@
 #!/bin/sh
-# shellcheck shell=dash disable=SC2169,SC2034,SC3010,SC3028,SC3015 source=/dev/null
+# shellcheck shell=dash disable=SC2169,SC2034,SC3010,SC3028,SC3014,SC3015 source=/dev/null
 #
 # Startup script checking for RF capabale hardware
 #
@@ -372,6 +372,10 @@ query_rf_parameters() {
     echo -n "${HM_HMIP_SERIAL}" >/var/board_serial
   elif [[ -n "${HM_HMRF_SERIAL}" ]]; then
     echo -n "${HM_HMRF_SERIAL}" >/var/board_serial
+  elif [[ "${HM_HOST}" == "oci" ]]; then
+    # in a docker/HA environment we have to use the hostname as a
+    # fake serial since the mac address changes on every boot
+    echo -n "$(hostname)" | sed 's/-openccu//g' >/var/board_serial
   else
     # fallback to put the mac in /var/board_serial
     MAC=$(cat /sys/class/net/"$(ip route show default | awk '/default/ {print $5}')"/address)


### PR DESCRIPTION
This PR modifies S47InitRFHardware and uses the hostname rather than the mac address as a fallback board serial in case OCI (e.g. HA) is used because in a OCI/Docker use case the mac address changes with every reboot which ends up in changing UPnP/SSDP identfiers. Now the hostname is used instead which should be kept unique on every HA app/add-on start. This fixes #4105.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hardware identification for OCI installations by deriving a board serial from the system hostname when needed.
  * Retained the MAC-address fallback for systems without a hostname-based identifier.

* **Chores**
  * Updated shell validation settings to support the revised initialization logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->