### PR TITLE
bump home-assistant-addon-proxy to 0.7.0

### DIFF
--- a/.github/workflows/release-proxy.yml
+++ b/.github/workflows/release-proxy.yml
@@ -6,6 +6,10 @@ name: Release Build (HA Proxy-Addon)
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build:
     runs-on: ubuntu-24.04

--- a/home-assistant-addon-proxy/CHANGELOG.md
+++ b/home-assistant-addon-proxy/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+## 0.7.0
+- implement session id (sid) cookie-base reuse to access the openccu webui with the same session id rathern than generating a new one on each access.
+- update HA app container dependencies
+- Bump http-proxy-middleware dependency to 4.2.0
+
 ## 0.6.1
 - Bump http-proxy-middleware dependency to 4.1.1
 

--- a/home-assistant-addon-proxy/Dockerfile
+++ b/home-assistant-addon-proxy/Dockerfile
@@ -6,7 +6,7 @@ COPY package.json /app/package.json
 COPY package-lock.json /app/package-lock.json
 RUN npm ci --omit=dev
 
-FROM ghcr.io/hassio-addons/base:20.1.1
+FROM ghcr.io/hassio-addons/base:21.0.1
 
 # set workdir to /app
 WORKDIR /app

--- a/home-assistant-addon-proxy/config.yaml
+++ b/home-assistant-addon-proxy/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: OpenCCU (Proxy)
-version: 0.6.1
+version: 0.7.0
 slug: openccu_proxy
 image: ghcr.io/openccu/openccu-proxy
 arch:

--- a/home-assistant-addon-proxy/package-lock.json
+++ b/home-assistant-addon-proxy/package-lock.json
@@ -1,20 +1,20 @@
 {
   "name": "openccu-ha-proxy",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openccu-ha-proxy",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "express": "5.2.1",
-        "http-proxy-middleware": "4.1.1",
+        "http-proxy-middleware": "4.2.0",
         "ipaddr.js": "2.4.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       }
     },
     "node_modules/accepts": {
@@ -454,13 +454,13 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-4.1.1.tgz",
-      "integrity": "sha512-KX5ZofGXLFXqFAkQoOWZ+rTtaLTut7m0gyL+QzJrdejtIZ+F4bPPDoe7reISg2+v0CAz5OfVwEJEhty7X+e57g==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-4.2.0.tgz",
+      "integrity": "sha512-ZA+oNOoM+GLoFTIzhkJptVQov73Srep2LBqhF8hG8CIPKO3nam1jonXVQ/QUH8RbwsmaaVz2SOJdzBNBHNtKbw==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.3",
-        "httpxy": "^0.5.3",
+        "httpxy": "^0.5.4",
         "is-glob": "^4.0.3",
         "is-plain-obj": "^4.1.0",
         "micromatch": "^4.0.8"
@@ -470,9 +470,9 @@
       }
     },
     "node_modules/httpxy": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/httpxy/-/httpxy-0.5.3.tgz",
-      "integrity": "sha512-SMS9V6Sn7VWaS11lYhoAr0ceoaiolTWf4jYdJn0NJhCdKMu9R2H9Fh0LBDWBHQF6HRLI1PmaePYsjanSpE5PEw==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/httpxy/-/httpxy-0.5.5.tgz",
+      "integrity": "sha512-uDjmnPyp1q4Sgzf3w+J/Fc6UqcCEj0x4Wjp7OqK5dGhNeDgpyrAmnS6ey8QWrX3SWDon2DMKf9sBa5X9+CVyMA==",
       "license": "MIT"
     },
     "node_modules/iconv-lite": {

--- a/home-assistant-addon-proxy/package.json
+++ b/home-assistant-addon-proxy/package.json
@@ -1,17 +1,17 @@
 {
   "name": "openccu-ha-proxy",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Proxy to externally running OpenCCU for Home Assistant ingress",
   "main": "ha-proxy.js",
   "private": true,
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   },
   "license": "Apache-2.0",
   "type": "commonjs",
   "dependencies": {
     "express": "5.2.1",
-    "http-proxy-middleware": "4.1.1",
+    "http-proxy-middleware": "4.2.0",
     "ipaddr.js": "2.4.0"
   }
 }


### PR DESCRIPTION
This PR bumps the home-assistant-addon-proxy HA app/add-on to version 0.7.0 to incorporate latest changes regarding session id cookie handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved session continuity by reusing session ID cookies where applicable.

* **Bug Fixes**
  * Updated proxy components and the Home Assistant add-on runtime for improved compatibility and reliability.

* **Chores**
  * Released version 0.7.0.
  * Raised the minimum supported Node.js version to 22.
  * Updated the underlying Home Assistant base image and proxy middleware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->