### PR TITLE
fix missing crontab entry removal upon CloudMatic disable

### DIFF
--- a/buildroot-external/package/cloudmatic/S97CloudMatic
+++ b/buildroot-external/package/cloudmatic/S97CloudMatic
@@ -36,9 +36,7 @@ start() {
 		# remove crontab entries if present
 		if grep -E -q "/mh/(cloudmaticcheck|loopupd)\.sh" /usr/local/crontabs/root 2>/dev/null; then
 			grep -E -v "/mh/(cloudmaticcheck|loopupd)\.sh" /usr/local/crontabs/root | sort | uniq >/tmp/crontab.$$
-			if [[ -s /tmp/crontab.$$ ]]; then
-				mv /tmp/crontab.$$ /usr/local/crontabs/root
-			fi
+			mv -f /tmp/crontab.$$ /usr/local/crontabs/root
 		fi
 		echo "disabled"
 	else

--- a/buildroot-external/package/cloudmatic/S97CloudMatic
+++ b/buildroot-external/package/cloudmatic/S97CloudMatic
@@ -33,6 +33,13 @@ start() {
 		if [[ -d /etc/config/addons/mh ]] && [[ ! -f /etc/config/addons/mh/client.key ]]; then
 			rm -rf /etc/config/addons/mh
 		fi
+		# remove crontab entries if present
+		if grep -E -q "/mh/(cloudmaticcheck|loopupd)\.sh" /usr/local/crontabs/root 2>/dev/null; then
+			grep -E -v "/mh/(cloudmaticcheck|loopupd)\.sh" /usr/local/crontabs/root | sort | uniq >/tmp/crontab.$$
+			if [[ -s /tmp/crontab.$$ ]]; then
+				mv /tmp/crontab.$$ /usr/local/crontabs/root
+			fi
+		fi
 		echo "disabled"
 	else
 		# CloudMatic (meine-homematic.de) startup


### PR DESCRIPTION
This PR adds a dedicated crontab entry removal in case CloudMatic is completely disabled using the extra settings to disable the CloudMatic addon functionality altogether. This fixes #4103.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Disabled CloudMatic installations now automatically remove related scheduled tasks from the system crontab.
  - Remaining crontab entries are sorted and deduplicated to keep scheduled tasks clean and consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->