### PR TITLE
bump wiringpi-odroid to df44ee6

### DIFF
--- a/buildroot-external/package/wiringpi-odroid/wiringpi-odroid.hash
+++ b/buildroot-external/package/wiringpi-odroid/wiringpi-odroid.hash
@@ -1,3 +1,3 @@
 # Locally computed
 sha256  da7eabb7bafdf7d3ae5e9f223aa5bdc1eece45ac569dc21b3b037520b4464768  COPYING.LESSER
-sha256  25abe08a13f926620af3d38d1e1f49663c2fca4a25f91a2e386565fa1a1ee503  wiringpi-odroid-0d2e0ad36197eec491db9434bed217d5e17aa71a.tar.gz
+sha256  53e8ac162939e5e956f41f4d07b46b8caf3030220425a978401fcb47283160a4  wiringpi-odroid-df44ee66a0ef9c7c27d3e47c07e40db913b7068c.tar.gz

--- a/buildroot-external/package/wiringpi-odroid/wiringpi-odroid.mk
+++ b/buildroot-external/package/wiringpi-odroid/wiringpi-odroid.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-WIRINGPI_ODROID_VERSION = 0d2e0ad36197eec491db9434bed217d5e17aa71a
+WIRINGPI_ODROID_VERSION = df44ee66a0ef9c7c27d3e47c07e40db913b7068c
 WIRINGPI_ODROID_SITE = $(call github,hardkernel,wiringPi,$(WIRINGPI_ODROID_VERSION))
 
 WIRINGPI_ODROID_LICENSE = LGPL-3.0+


### PR DESCRIPTION
Dependency update generated by nightly update check workflow.

Updated component:
- Name...: `wiringpi-odroid`
- Package: `wiringpi-odroid`
- Current version: `0d2e0ad`
- New version....: `df44ee6`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled WiringPi ODROID source to a newer upstream revision.
  * Refreshed the associated source archive and checksum references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->