### PR TITLE
bump rpi-eeprom to 8428000

### DIFF
--- a/buildroot-external/package/rpi-eeprom/rpi-eeprom.hash
+++ b/buildroot-external/package/rpi-eeprom/rpi-eeprom.hash
@@ -1,3 +1,3 @@
 # Locally computed
 sha256  594b7565fd3ccf8acd4711a2ec1b199181aafbc3426d0bacaa50ef40edbf7c4a  LICENSE
-sha256  13a3966de52bcf5c808c31d5b032f980aab97f8fa1c1851c50bd32850bb5b5d6  rpi-eeprom-6609691dc45f92bc0a8bbd1ac92dd0c0ff54ab5c.tar.gz
+sha256  50ef8d9bb0b07b1b71c7b76599b323ab49d74c7cd55445fbdcf65650c05306d9  rpi-eeprom-842800056e3eec923e33f50897d6e6a464c398a5.tar.gz

--- a/buildroot-external/package/rpi-eeprom/rpi-eeprom.mk
+++ b/buildroot-external/package/rpi-eeprom/rpi-eeprom.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-RPI_EEPROM_VERSION = 6609691dc45f92bc0a8bbd1ac92dd0c0ff54ab5c
+RPI_EEPROM_VERSION = 842800056e3eec923e33f50897d6e6a464c398a5
 RPI_EEPROM_SITE = $(call github,raspberrypi,rpi-eeprom,$(RPI_EEPROM_VERSION))
 RPI_EEPROM_LICENSE = BSD-3-Clause, MIT, uIP, custom
 RPI_EEPROM_LICENSE_FILES = LICENSE


### PR DESCRIPTION
Dependency update generated by nightly update check workflow.

Updated component:
- Name...: `rpi-eeprom`
- Package: `rpi-eeprom`
- Current version: `6609691`
- New version....: `8428000`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Raspberry Pi EEPROM package to a newer upstream revision.
  * Refreshed the source archive filename and SHA-256 checksum to match the updated release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->