### PR TITLE
bump qemu-guest-agent to 11.1.1

### DIFF
--- a/buildroot-external/package/qemu-guest-agent/qemu-guest-agent.hash
+++ b/buildroot-external/package/qemu-guest-agent/qemu-guest-agent.hash
@@ -1,4 +1,4 @@
 # Locally computed
 sha256  dd3ce02338c3a48abb6ba59b48809f7108a8bd242cb0cc8be90daafa30707c28  COPYING
 sha256  31c90ce76b6f5aab90a205851e71d5c27e31c0aa3d7017a4383b98a6fe3f1faa  COPYING.LIB
-sha256  6ee1d1a61f68212476b27108c26da5f449dc09b626d42f8279ba0dc2e08fa858  qemu-11.1.0.tar.xz
+sha256  079ffbff8a7111bbc89022107cbabf3bbfd614d5fc9d7cc675991196aca12482  qemu-11.1.1.tar.xz

--- a/buildroot-external/package/qemu-guest-agent/qemu-guest-agent.mk
+++ b/buildroot-external/package/qemu-guest-agent/qemu-guest-agent.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-QEMU_GUEST_AGENT_VERSION = 11.1.0
+QEMU_GUEST_AGENT_VERSION = 11.1.1
 QEMU_GUEST_AGENT_SOURCE = qemu-$(QEMU_GUEST_AGENT_VERSION).tar.xz
 QEMU_GUEST_AGENT_SITE = https://download.qemu.org
 QEMU_GUEST_AGENT_LICENSE = GPL-2.0, LGPL-2.1, MIT, BSD-3-Clause, BSD-2-Clause, Others/BSD-1c


### PR DESCRIPTION
Dependency update generated by nightly update check workflow.

Updated component:
- Name...: `qemu-guest-agent`
- Package: `qemu-guest-agent`
- Current version: `11.1.0`
- New version....: `11.1.1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the QEMU guest agent package to version 11.1.1.
  * Updated the associated source archive and checksum to match the new release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->