### PR TITLE
rpi: disable energy efficient ethernet (802.3az) to improve link stability

### DIFF
--- a/buildroot-external/board/rpi3/config.txt
+++ b/buildroot-external/board/rpi3/config.txt
@@ -42,6 +42,9 @@ dtoverlay=miniuart-bt
 # disable the splash screen
 disable_splash=1
 
+# disable IEEE 802.3az Energy Efficient Ethernet for link stability
+dtparam=eee=off
+
 # activating the hardware watchdog
 dtparam=watchdog=on
 

--- a/buildroot-external/board/rpi4/config.txt
+++ b/buildroot-external/board/rpi4/config.txt
@@ -43,6 +43,9 @@ dtoverlay=miniuart-bt
 # disable the splash screen
 disable_splash=1
 
+# disable IEEE 802.3az Energy Efficient Ethernet for link stability
+dtparam=eee=off
+
 # activating the hardware watchdog
 dtparam=watchdog=on
 

--- a/buildroot-external/board/rpi5/config.txt
+++ b/buildroot-external/board/rpi5/config.txt
@@ -39,6 +39,9 @@ enable_uart=1
 # disable the splash screen
 disable_splash=1
 
+# disable IEEE 802.3az Energy Efficient Ethernet for link stability
+dtparam=eee=off
+
 # activating the hardware watchdog
 dtparam=watchdog=on
 


### PR DESCRIPTION
This PR adds `dtparam=eee=off` to `/boot/config.txt` to ensure any energe efficient ethernet feature is turned off to potentially improve link stability (cf. https://homematic-forum.de/forum/viewtopic.php?f=65&t=50692&p=864285#p864280, https://github.com/home-assistant/operating-system/issues/4861)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Ethernet link stability on Raspberry Pi 3, 4, and 5 devices.
  * Disabled Energy Efficient Ethernet, which could contribute to intermittent network connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->