### PR TITLE
bump wiringpi-rpi to v3.20

### DIFF
--- a/buildroot-external/package/wiringpi-rpi/wiringpi-rpi.hash
+++ b/buildroot-external/package/wiringpi-rpi/wiringpi-rpi.hash
@@ -1,3 +1,3 @@
 # Locally computed
 sha256  da7eabb7bafdf7d3ae5e9f223aa5bdc1eece45ac569dc21b3b037520b4464768  COPYING.LESSER
-sha256  c7a06c462372df1650219a10cdd4e8e1da763a41399539ecd1ee1dd4e14e09a8  wiringpi-rpi-3.18.tar.gz
+sha256  814ec49877c7df98cf996c3261f71df283b048573ea2c548099e5042f8cce04e  wiringpi-rpi-v3.20.tar.gz

--- a/buildroot-external/package/wiringpi-rpi/wiringpi-rpi.mk
+++ b/buildroot-external/package/wiringpi-rpi/wiringpi-rpi.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-WIRINGPI_RPI_VERSION = 3.18
+WIRINGPI_RPI_VERSION = v3.20
 WIRINGPI_RPI_SITE = $(call github,wiringpi,wiringpi,$(WIRINGPI_RPI_VERSION))
 
 WIRINGPI_RPI_LICENSE = LGPL-3.0+


### PR DESCRIPTION
Dependency update generated by nightly update check workflow.

Updated component:
- Name...: `wiringpi-rpi`
- Package: `wiringpi-rpi`
- Current version: `3.18`
- New version....: `v3.20`

> [!WARNING]
> Patch apply check failed for package `wiringpi-rpi`.
> The version bump likely requires updates to the existing patch files before this change can be merged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the WiringPi-RPi package to version 3.20.
  * Updated the associated source verification checksum.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->