### PR TITLE
update openccu-base to ff6939f to fix libXmlRpc issue

### DIFF
--- a/buildroot-external/package/openccu-base/openccu-base.mk
+++ b/buildroot-external/package/openccu-base/openccu-base.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-OPENCCU_BASE_VERSION = 881dcf7e286cc873d267f97e14ba6a87506df80b
+OPENCCU_BASE_VERSION = ff6939fdc9815a1944b85464052faf83610165e5
 OPENCCU_BASE_COMPAT_VERSION = 3.89.8
 OPENCCU_BASE_SITE = https://github.com/OpenCCU/OpenCCU-Base
 OPENCCU_BASE_SITE_METHOD = git


### PR DESCRIPTION
This updates OpenCCU-base to ff6939f which includes libXmlRpc 0.10 fixing a libXmlRpc related issue (cf. #4138).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled OpenCCU Base version to a newer release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->