### PR TITLE
bump daemonize to release-1.7.8

### DIFF
--- a/buildroot-external/package/daemonize/daemonize.hash
+++ b/buildroot-external/package/daemonize/daemonize.hash
@@ -1,3 +1,3 @@
 # Locally computed
 sha256  8a4306c315b0d2975f2b70fa17ab1e193b32a674759e736442174d748ab27fbe  LICENSE.md
-sha256  9ab70fd8ecaa9576f33944a3b7be942dffa036b92a0631f7db2ab3f81c4613ed  daemonize-d29dc4ad02f080750597f1fe8e14a667ba43247f.tar.gz
+sha256  20c4fc9925371d1ddf1b57947f8fb93e2036eb9ccc3b43a1e3678ea8471c4c60  daemonize-release-1.7.8.tar.gz

--- a/buildroot-external/package/daemonize/daemonize.mk
+++ b/buildroot-external/package/daemonize/daemonize.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-DAEMONIZE_VERSION = d29dc4ad02f080750597f1fe8e14a667ba43247f
+DAEMONIZE_VERSION = release-1.7.8
 DAEMONIZE_SITE = $(call github,bmc,daemonize,$(DAEMONIZE_VERSION))
 DAEMONIZE_LICENSE = BSD-2-Clause
 DAEMONIZE_LICENSE_FILES = LICENSE.md


### PR DESCRIPTION
Dependency update generated by nightly update check workflow.

Updated component:
- Name...: `daemonize`
- Package: `daemonize`
- Current version: `d29dc4a`
- New version....: `release-1.7.8`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the daemonize package to release version 1.7.8.
  * Updated the associated source archive verification data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->