### PR TITLE
vcgencmd: fix callback prototype for C23/GCC15 compatibility

### DIFF
--- a/buildroot-external/package/vcgencmd/0002-fix-gpuserv-callback-prototype.patch
+++ b/buildroot-external/package/vcgencmd/0002-fix-gpuserv-callback-prototype.patch
@@ -1,0 +1,21 @@
+Subject: [PATCH] vmcs_host: specify GPU service callback parameter for C23
+
+The GPU service invokes this callback with its void *cookie argument.
+Since C23 an empty parameter list means no parameters, so GCC 15 rejects
+that call. Declare the existing callback argument explicitly.
+
+Upstream: Not applicable
+
+Signed-off-by: Jens Maus <mail@jens-maus.de>
+
+--- a/interface/vmcs_host/vc_vchi_gpuserv.h
++++ b/interface/vmcs_host/vc_vchi_gpuserv.h
+@@ -58,7 +58,7 @@
+ 
+ struct gpu_callback_s {
+   // callback to call when complete (can be NULL)
+-  void (*func)();
++  void (*func)(void *cookie);
+   void *cookie;
+ };
+ 


### PR DESCRIPTION
This fixes a missng callback prototype which blocked vcgencmd compilation on GCC15 (C23) environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed GPU service callback compatibility with newer C23/GCC 15 toolchains.
  - Ensured callback handlers correctly receive the provided context parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->