### PR TITLE
fix root ash-shell related dotfiles to link to the correct locations

### DIFF
--- a/buildroot-external/overlay/base/root/.ash_history
+++ b/buildroot-external/overlay/base/root/.ash_history
@@ -1,0 +1,1 @@
+/var/tmp/ash_history

--- a/buildroot-external/overlay/base/root/.ashrc
+++ b/buildroot-external/overlay/base/root/.ashrc
@@ -1,0 +1,1 @@
+/usr/local/etc/ashrc

--- a/buildroot-external/overlay/base/root/.bash_logout
+++ b/buildroot-external/overlay/base/root/.bash_logout
@@ -1,9 +1,0 @@
-#!/bin/sh
-# shellcheck shell=dash
-# ~/.bash_logout: executed by bash(1) when login shell exits.
-
-# when leaving the console clear the screen to increase privacy
-
-case "$(tty)" in
-    /dev/tty[0-9]*) clear
-esac

--- a/buildroot-external/overlay/base/root/.bash_profile
+++ b/buildroot-external/overlay/base/root/.bash_profile
@@ -1,6 +1,0 @@
-#!/bin/sh
-# shellcheck shell=dash source=/dev/null
-# .bash_profile
-if [ -f ~/.bashrc ]; then
-    . ~/.bashrc
-fi

--- a/buildroot-external/overlay/base/root/.profile
+++ b/buildroot-external/overlay/base/root/.profile
@@ -1,0 +1,5 @@
+#!/bin/sh
+# shellcheck shell=dash source=/dev/null
+if [ -f ~/.ashrc ]; then
+    . ~/.ashrc
+fi


### PR DESCRIPTION
This fixes the /root located dotfiles where bash_profile was never actually used, ash_history did not link to a tmpfs location and ashrc not being linked to a permanent location under /usr/local/etc to allow users to define login commands being executed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added standardized root-shell configuration links for command history and interactive shell settings.
  - Added a profile that loads the configured shell settings when available.

- **Changes**
  - Removed legacy Bash startup configuration and logout handling.
  - Exiting a login shell on a physical console no longer automatically clears the screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->