### PR TITLE
bump rpi-eeprom to 279e8b8

### DIFF
--- a/buildroot-external/package/rpi-eeprom/rpi-eeprom.hash
+++ b/buildroot-external/package/rpi-eeprom/rpi-eeprom.hash
@@ -1,3 +1,3 @@
 # Locally computed
 sha256  594b7565fd3ccf8acd4711a2ec1b199181aafbc3426d0bacaa50ef40edbf7c4a  LICENSE
-sha256  19372f1857357fd3075cf07f892c742c9e6bdb1b19ea0c0cb22949867e97631d  rpi-eeprom-a1e23df26912555e83ab3b1eecfb7bf4e9da9448.tar.gz
+sha256  db1e5a45b2a5f9f81fc6970a9a270fb2a48be53f3dc44fc9b02b234c203b5dc0  rpi-eeprom-279e8b86fd038f026a8daad1223305a15a7d1f2b.tar.gz

--- a/buildroot-external/package/rpi-eeprom/rpi-eeprom.mk
+++ b/buildroot-external/package/rpi-eeprom/rpi-eeprom.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-RPI_EEPROM_VERSION = a1e23df26912555e83ab3b1eecfb7bf4e9da9448
+RPI_EEPROM_VERSION = 279e8b86fd038f026a8daad1223305a15a7d1f2b
 RPI_EEPROM_SITE = $(call github,raspberrypi,rpi-eeprom,$(RPI_EEPROM_VERSION))
 RPI_EEPROM_LICENSE = BSD-3-Clause, MIT, uIP, custom
 RPI_EEPROM_LICENSE_FILES = LICENSE
@@ -17,7 +17,7 @@ ifeq ($(BR2_PACKAGE_RPI_EEPROM_RPI4),y)
   RPI_EEPROM_VL805_GLOB = firmware-2711/stable/vl805-*.bin
 else ifeq ($(BR2_PACKAGE_RPI_EEPROM_RPI5),y)
   # Raspberry Pi 5 (2712)
-  RPI_EEPROM_FIRMWARE_PATH = firmware-2712/stable/pieeprom-2026-08-12.bin
+  RPI_EEPROM_FIRMWARE_PATH = firmware-2712/stable/pieeprom-2026-09-10.bin
   RPI_EEPROM_RECOVERY_PATH = firmware-2712/stable/recovery.bin
 endif
 


### PR DESCRIPTION
Dependency update generated by nightly update check workflow.

Updated component:
- Name...: `rpi-eeprom`
- Package: `rpi-eeprom`
- Current version: `a1e23df`
- New version....: `279e8b8`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Raspberry Pi EEPROM package to a newer upstream release.
  * Updated the Raspberry Pi 5 stable firmware binary.
  * Refreshed the associated source archive checksum.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->