### PR TITLE
bump openccu-base to 5b47e37

### DIFF
--- a/buildroot-external/package/openccu-base/openccu-base.mk
+++ b/buildroot-external/package/openccu-base/openccu-base.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-OPENCCU_BASE_VERSION = d0d6966cb47f7142c8d562cda9e18325b2d7addd
+OPENCCU_BASE_VERSION = 5b47e37cf4da97275de26da8469881383de452cd
 OPENCCU_BASE_COMPAT_VERSION = 3.89.8
 OPENCCU_BASE_SITE = https://github.com/OpenCCU/OpenCCU-Base
 OPENCCU_BASE_SITE_METHOD = git


### PR DESCRIPTION
Dependency update generated by nightly update check workflow.

Updated component:
- Name...: `openccu-base`
- Package: `openccu-base`
- Current version: `d0d6966`
- New version....: `5b47e37`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled OpenCCU-Base package revision to a newer upstream version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->