### PR TITLE
bump OpenCCU-Base to 3.89.9

### DIFF
--- a/buildroot-external/package/openccu-base/openccu-base.mk
+++ b/buildroot-external/package/openccu-base/openccu-base.mk
@@ -4,8 +4,8 @@
 #
 ################################################################################
 
-OPENCCU_BASE_VERSION = 5b47e37cf4da97275de26da8469881383de452cd
-OPENCCU_BASE_COMPAT_VERSION = 3.89.8
+OPENCCU_BASE_VERSION = 3.89.9
+OPENCCU_BASE_COMPAT_VERSION = 3.89.9
 OPENCCU_BASE_SITE = https://github.com/OpenCCU/OpenCCU-Base
 OPENCCU_BASE_SITE_METHOD = git
 OPENCCU_BASE_LICENSE = HMSL-2.0, Apache-2.0 (WebUI), \


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the OpenCCU-Base package to version 3.89.9.
  * Updated the reported compatibility version to 3.89.9.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->