### PR TITLE
bump rpi-eeprom to da7cd20

### DIFF
--- a/buildroot-external/package/rpi-eeprom/rpi-eeprom.hash
+++ b/buildroot-external/package/rpi-eeprom/rpi-eeprom.hash
@@ -1,3 +1,3 @@
 # Locally computed
 sha256  594b7565fd3ccf8acd4711a2ec1b199181aafbc3426d0bacaa50ef40edbf7c4a  LICENSE
-sha256  db1e5a45b2a5f9f81fc6970a9a270fb2a48be53f3dc44fc9b02b234c203b5dc0  rpi-eeprom-279e8b86fd038f026a8daad1223305a15a7d1f2b.tar.gz
+sha256  b42adb209797354484cddd2799556db7d60c49cd37157f65e96f67937d861c3b  rpi-eeprom-da7cd207d7ee97361ff76e1390634afae05aa3fa.tar.gz

--- a/buildroot-external/package/rpi-eeprom/rpi-eeprom.mk
+++ b/buildroot-external/package/rpi-eeprom/rpi-eeprom.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-RPI_EEPROM_VERSION = 279e8b86fd038f026a8daad1223305a15a7d1f2b
+RPI_EEPROM_VERSION = da7cd207d7ee97361ff76e1390634afae05aa3fa
 RPI_EEPROM_SITE = $(call github,raspberrypi,rpi-eeprom,$(RPI_EEPROM_VERSION))
 RPI_EEPROM_LICENSE = BSD-3-Clause, MIT, uIP, custom
 RPI_EEPROM_LICENSE_FILES = LICENSE
@@ -12,12 +12,12 @@ RPI_EEPROM_INSTALL_IMAGES = YES
 
 ifeq ($(BR2_PACKAGE_RPI_EEPROM_RPI4),y)
   # Raspberry Pi 4 (2711)
-  RPI_EEPROM_FIRMWARE_PATH = firmware-2711/stable/pieeprom-2026-08-04.bin
+  RPI_EEPROM_FIRMWARE_PATH = firmware-2711/stable/pieeprom-2026-09-12.bin
   RPI_EEPROM_RECOVERY_PATH = firmware-2711/stable/recovery.bin
   RPI_EEPROM_VL805_GLOB = firmware-2711/stable/vl805-*.bin
 else ifeq ($(BR2_PACKAGE_RPI_EEPROM_RPI5),y)
   # Raspberry Pi 5 (2712)
-  RPI_EEPROM_FIRMWARE_PATH = firmware-2712/stable/pieeprom-2026-09-10.bin
+  RPI_EEPROM_FIRMWARE_PATH = firmware-2712/stable/pieeprom-2026-09-12.bin
   RPI_EEPROM_RECOVERY_PATH = firmware-2712/stable/recovery.bin
 endif
 


### PR DESCRIPTION
Dependency update generated by nightly update check workflow.

Updated component:
- Name...: `rpi-eeprom`
- Package: `rpi-eeprom`
- Current version: `279e8b8`
- New version....: `da7cd20`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the Raspberry Pi EEPROM package to a newer upstream revision.
  * Updated stable firmware images for Raspberry Pi 4 and Raspberry Pi 5 to the latest available versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->